### PR TITLE
Feat: article 작성 모달 파이어베이스 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "next": "14.2.14",
     "react": "18",
     "react-dom": "18",
-    "react-markdown": "^10.1.0",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/src/app/(common-layout)/article/page.tsx
+++ b/src/app/(common-layout)/article/page.tsx
@@ -14,7 +14,7 @@ export default function Article() {
   };
 
   const handleOpenRead = () => {
-    open(<ReadArticleModal />);
+    open(<ReadArticleModal studyRoomId="2Gyk5YwplLm61vnxHsyE" articleId="zSIy9Hk3E0aOBIBbYiLf" />);
   };
 
   console.log("Article 렌더링됨");

--- a/src/app/(common-layout)/article/page.tsx
+++ b/src/app/(common-layout)/article/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import AddArticleModal from "@/app/_component/domain/addarticle/AddArticleModal";
-import ReadArticleModal from "@/app/_component/domain/readArticle/ReadArticleModal";
+import React from "react";
+
 import { useModalStore } from "@/store/useModalStore";
 
-import React from "react";
+import AddArticleModal from "@/app/_component/domain/addarticle/AddArticleModal";
+import ReadArticleModal from "@/app/_component/domain/readArticle/ReadArticleModal";
 
 export default function Article() {
   const open = useModalStore(state => state.open);
@@ -14,7 +15,7 @@ export default function Article() {
   };
 
   const handleOpenRead = () => {
-    open(<ReadArticleModal studyRoomId="2Gyk5YwplLm61vnxHsyE" articleId="zSIy9Hk3E0aOBIBbYiLf" />);
+    open(<ReadArticleModal studyRoomId="2Gyk5YwplLm61vnxHsyE" articleId="Dwm85DUpikiivhhwpnMB" />);
   };
 
   console.log("Article 렌더링됨");

--- a/src/app/(common-layout)/article/page.tsx
+++ b/src/app/(common-layout)/article/page.tsx
@@ -8,12 +8,15 @@ import React from "react";
 
 export default function Article() {
   const open = useModalStore(state => state.open);
+
   const handleOpenAdd = () => {
-    open(<AddArticleModal />);
+    open(<AddArticleModal studyRoomId="2Gyk5YwplLm61vnxHsyE" />);
   };
+
   const handleOpenRead = () => {
     open(<ReadArticleModal />);
   };
+
   console.log("Article 렌더링됨");
 
   return (

--- a/src/app/(common-layout)/article/page.tsx
+++ b/src/app/(common-layout)/article/page.tsx
@@ -1,13 +1,30 @@
-import AddArticleModal from "@/app/_component/addarticle/AddArticleModal";
-// import ReadArticleModal from "@/app/_component/readArticle/ReadArticleModal";
+"use client";
+
+import AddArticleModal from "@/app/_component/domain/addarticle/AddArticleModal";
+import ReadArticleModal from "@/app/_component/domain/readArticle/ReadArticleModal";
+import { useModalStore } from "@/store/useModalStore";
 
 import React from "react";
 
 export default function Article() {
+  const open = useModalStore(state => state.open);
+  const handleOpenAdd = () => {
+    open(<AddArticleModal />);
+  };
+  const handleOpenRead = () => {
+    open(<ReadArticleModal />);
+  };
+  console.log("Article 렌더링됨");
+
   return (
-    <div>
-      <AddArticleModal />
-      {/* <ReadArticleModal /> */}
+    <div style={{ paddingTop: "150px" }}>
+      <button onClick={handleOpenAdd} style={{ cursor: "pointer" }}>
+        추가하기
+      </button>
+
+      <button onClick={handleOpenRead} style={{ cursor: "pointer" }}>
+        읽기
+      </button>
     </div>
   );
 }

--- a/src/app/(common-layout)/article/page.tsx
+++ b/src/app/(common-layout)/article/page.tsx
@@ -21,7 +21,7 @@ export default function Article() {
   console.log("Article 렌더링됨");
 
   return (
-    <div style={{ paddingTop: "150px" }}>
+    <div style={{ paddingTop: "15rem" }}>
       <button onClick={handleOpenAdd} style={{ cursor: "pointer" }}>
         추가하기
       </button>

--- a/src/app/_component/domain/addarticle/AddArticleModal.module.css
+++ b/src/app/_component/domain/addarticle/AddArticleModal.module.css
@@ -20,7 +20,7 @@
   width: 128rem;
   height: 68rem;
   padding: 3rem;
-
+  margin-top: 11.5rem;
   border-radius: 20px;
   border: 1.5px solid rgba(255, 255, 255, 0.1);
 

--- a/src/app/_component/domain/addarticle/AddArticleModal.module.css
+++ b/src/app/_component/domain/addarticle/AddArticleModal.module.css
@@ -55,7 +55,3 @@
   flex-direction: column;
   gap: 2.4rem;
 }
-
-.cursorPointer {
-  cursor: pointer;
-}

--- a/src/app/_component/domain/addarticle/AddArticleModal.tsx
+++ b/src/app/_component/domain/addarticle/AddArticleModal.tsx
@@ -16,7 +16,10 @@ import ICDelete from "@/assets/icon/delete.svg";
 
 import styles from "./AddArticleModal.module.css";
 
-const ToastEditor = dynamic(() => import("./ToastEditor"), { ssr: false });
+const ToastEditor = dynamic(() => import("./ToastEditor"), {
+  ssr: false,
+  loading: () => <p>잠시만 기다려주세요...</p>
+});
 
 interface Props {
   studyRoomId: string;

--- a/src/app/_component/domain/addarticle/AddArticleModal.tsx
+++ b/src/app/_component/domain/addarticle/AddArticleModal.tsx
@@ -5,18 +5,25 @@ import React from "react";
 import styles from "./AddArticleModal.module.css";
 import Titlebox from "./Titlebox";
 import ICDelete from "@/assets/icon/delete.svg";
+import { useModalStore } from "@/store/useModalStore";
+import DeleteModal from "./DeleteModal";
 
 const AddArticleModal = () => {
   const ToastEditor = dynamic(() => import("./ToastEditor"), {
     ssr: false
   });
 
+  const open = useModalStore(state => state.open);
+  const handleOpenDelete = () => {
+    open(<DeleteModal />);
+  };
+
   return (
     <div className={styles.overlay}>
       <div className={styles.modalBox}>
         <div className={styles.topSection}>
           <p>Article 생성하기</p>
-          <ICDelete className={styles.cursorPointer} />
+          <ICDelete onClick={handleOpenDelete} style={{ cursor: "pointer" }} />
         </div>
         <div className={styles.bodySection}>
           <div className={styles.leftSection}>
@@ -24,9 +31,6 @@ const AddArticleModal = () => {
             <ToastEditor />
           </div>
         </div>
-        {/* <div className={styles.buttonSection}>
-          <button type="button">생성하기</button>
-        </div> */}
       </div>
     </div>
   );

--- a/src/app/_component/domain/addarticle/AddArticleModal.tsx
+++ b/src/app/_component/domain/addarticle/AddArticleModal.tsx
@@ -27,7 +27,8 @@ interface Props {
 
 const AddArticleModal = ({ studyRoomId }: Props) => {
   console.log(studyRoomId);
-  const { name, year } = useUserStore();
+  const { name, year, uid } = useUserStore();
+
   const { isLoggedIn } = useAuth();
   const open = useModalStore(state => state.open);
   const handleOpenDelete = () => open(<DeleteModal />);
@@ -49,6 +50,7 @@ const AddArticleModal = ({ studyRoomId }: Props) => {
         content: markdown,
         creatorName: name,
         creatorYear: year,
+        creatorId: uid,
         createdAt: serverTimestamp()
       });
 

--- a/src/app/_component/domain/addarticle/AddArticleModal.tsx
+++ b/src/app/_component/domain/addarticle/AddArticleModal.tsx
@@ -1,22 +1,22 @@
 "use client";
 import dynamic from "next/dynamic";
-
-import React from "react";
+import React, { useState } from "react";
 import styles from "./AddArticleModal.module.css";
 import Titlebox from "./Titlebox";
 import ICDelete from "@/assets/icon/delete.svg";
 import { useModalStore } from "@/store/useModalStore";
 import DeleteModal from "./DeleteModal";
 
-const AddArticleModal = () => {
-  const ToastEditor = dynamic(() => import("./ToastEditor"), {
-    ssr: false
-  });
+const ToastEditor = dynamic(() => import("./ToastEditor"), { ssr: false });
 
+const AddArticleModal = () => {
   const open = useModalStore(state => state.open);
-  const handleOpenDelete = () => {
-    open(<DeleteModal />);
-  };
+  const handleOpenDelete = () => open(<DeleteModal />);
+
+  const [title, setTitle] = useState<string>(() => localStorage.getItem("draft-title") || "");
+  const [markdown, setMarkdown] = useState<string>(
+    () => localStorage.getItem("draft-markdown") || ""
+  );
 
   return (
     <div className={styles.overlay}>
@@ -27,8 +27,8 @@ const AddArticleModal = () => {
         </div>
         <div className={styles.bodySection}>
           <div className={styles.leftSection}>
-            <Titlebox />
-            <ToastEditor />
+            <Titlebox title={title} setTitle={setTitle} markdown={markdown} />
+            <ToastEditor setMarkdown={setMarkdown} />
           </div>
         </div>
       </div>

--- a/src/app/_component/domain/addarticle/AddArticleModal.tsx
+++ b/src/app/_component/domain/addarticle/AddArticleModal.tsx
@@ -1,22 +1,64 @@
 "use client";
+
 import dynamic from "next/dynamic";
 import React, { useState } from "react";
-import styles from "./AddArticleModal.module.css";
+
+import { useModalStore } from "@/store/useModalStore";
+import { useUserStore } from "@/store/useUserStore";
+import { useAuth } from "@/hooks/useAuth";
+import DeleteModal from "./DeleteModal";
+
+import { collection, addDoc, serverTimestamp } from "firebase/firestore";
+import fireStore from "@/firebase/firestore";
+
 import Titlebox from "./Titlebox";
 import ICDelete from "@/assets/icon/delete.svg";
-import { useModalStore } from "@/store/useModalStore";
-import DeleteModal from "./DeleteModal";
+
+import styles from "./AddArticleModal.module.css";
 
 const ToastEditor = dynamic(() => import("./ToastEditor"), { ssr: false });
 
-const AddArticleModal = () => {
+interface Props {
+  studyRoomId: string;
+}
+
+const AddArticleModal = ({ studyRoomId }: Props) => {
+  console.log(studyRoomId);
+  const { name, year } = useUserStore();
+  const { isLoggedIn } = useAuth();
   const open = useModalStore(state => state.open);
   const handleOpenDelete = () => open(<DeleteModal />);
 
-  const [title, setTitle] = useState<string>(() => localStorage.getItem("draft-title") || "");
-  const [markdown, setMarkdown] = useState<string>(
-    () => localStorage.getItem("draft-markdown") || ""
-  );
+  const [title, setTitle] = useState(() => localStorage.getItem("draft-title") || "");
+  const [markdown, setMarkdown] = useState(() => localStorage.getItem("draft-markdown") || "");
+
+  const handleSubmit = async () => {
+    try {
+      if (!isLoggedIn) {
+        alert("로그인이 필요합니다.");
+        return;
+      }
+
+      const articleRef = collection(fireStore, "studyRooms", studyRoomId, "articles");
+
+      await addDoc(articleRef, {
+        title,
+        content: markdown,
+        creatorName: name,
+        creatorYear: year,
+        createdAt: serverTimestamp()
+      });
+
+      localStorage.removeItem("draft-title");
+      localStorage.removeItem("draft-markdown");
+
+      useModalStore.getState().close();
+      alert("성공적으로 생성되었습니다!");
+    } catch (error) {
+      console.error("생성 중 오류:", error);
+      alert("생성에 실패했습니다.");
+    }
+  };
 
   return (
     <div className={styles.overlay}>
@@ -27,7 +69,12 @@ const AddArticleModal = () => {
         </div>
         <div className={styles.bodySection}>
           <div className={styles.leftSection}>
-            <Titlebox title={title} setTitle={setTitle} markdown={markdown} />
+            <Titlebox
+              title={title}
+              setTitle={setTitle}
+              markdown={markdown}
+              onSubmit={handleSubmit}
+            />
             <ToastEditor setMarkdown={setMarkdown} />
           </div>
         </div>

--- a/src/app/_component/domain/addarticle/DeleteModal.module.css
+++ b/src/app/_component/domain/addarticle/DeleteModal.module.css
@@ -1,0 +1,67 @@
+.modal {
+  position: relative;
+  display: flex;
+  padding: 2.4rem;
+  flex-direction: column;
+  align-items: flex-start;
+  border-radius: 20px;
+  border: 1.302px solid rgba(255, 255, 255, 0.1);
+  background: #1a1a1a;
+  gap: 1.8rem;
+}
+
+.modalHeader {
+  width: 38rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.titleText {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.bodyContainer > p {
+  color: var(--Basic-White, #fff);
+
+  font-family: Pretendard;
+  font-size: 1.4rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 22px;
+}
+.keepBtn,
+.stopBtn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.491rem;
+  border-radius: 24.551px;
+  border: 0.818px solid #585858;
+  width: 9rem;
+  height: 2.8rem;
+  font-family: Pretendard;
+  font-size: 1.1rem;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 1.4rem;
+  cursor: pointer;
+}
+.stopBtn {
+  background-color: #fff;
+  color: #1a1a1a;
+}
+
+.keepBtn {
+  background-color: transparent;
+  color: #c6c6c6;
+}
+.btnWrapper {
+  width: 100%;
+  display: flex;
+  gap: 0.4rem;
+  justify-content: flex-end;
+  align-items: center;
+}

--- a/src/app/_component/domain/addarticle/DeleteModal.tsx
+++ b/src/app/_component/domain/addarticle/DeleteModal.tsx
@@ -12,7 +12,7 @@ export default function LogoutModalContent() {
 
   const handleKeepWriting = () => {
     close();
-    open(<AddArticleModal />);
+    open(<AddArticleModal studyRoomId="2Gyk5YwplLm61vnxHsyE" />);
   };
 
   const handleStopWriting = () => {

--- a/src/app/_component/domain/addarticle/DeleteModal.tsx
+++ b/src/app/_component/domain/addarticle/DeleteModal.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import React from "react";
+import { useModalStore } from "@/store/useModalStore";
+import ICDelete from "@/assets/icon/delete.svg";
+import modalStyles from "@/app/_component/common/Modal.module.css";
+import styles from "./DeleteModal.module.css";
+import AddArticleModal from "./AddArticleModal";
+
+export default function LogoutModalContent() {
+  const { close, open } = useModalStore();
+
+  const handleKeepWriting = () => {
+    close();
+    open(<AddArticleModal />);
+  };
+
+  const handleStopWriting = () => {
+    localStorage.removeItem("draft-title");
+    localStorage.removeItem("draft-markdown");
+    close();
+  };
+
+  return (
+    <div className={modalStyles.modal}>
+      <div className={styles.modalHeader}>
+        <p className={modalStyles.modalTitle}>Article 작성을 그만두시겠습니까?</p>
+        <ICDelete onClick={close} style={{ cursor: "pointer" }} />
+      </div>
+      <div className={styles.bodyContainer}>
+        <p>지금 중단하면 저장이 되지 않습니다.</p>
+      </div>
+      <div className={styles.btnWrapper}>
+        <button onClick={handleKeepWriting} className={styles.keepBtn}>
+          이어서 작성하기
+        </button>
+        <button onClick={handleStopWriting} className={styles.stopBtn}>
+          작성 중단하기
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/_component/domain/addarticle/DeleteModal.tsx
+++ b/src/app/_component/domain/addarticle/DeleteModal.tsx
@@ -7,7 +7,7 @@ import modalStyles from "@/app/_component/common/Modal.module.css";
 import styles from "./DeleteModal.module.css";
 import AddArticleModal from "./AddArticleModal";
 
-export default function LogoutModalContent() {
+export default function DeleteModal() {
   const { close, open } = useModalStore();
 
   const handleKeepWriting = () => {

--- a/src/app/_component/domain/addarticle/Titlebox.module.css
+++ b/src/app/_component/domain/addarticle/Titlebox.module.css
@@ -72,12 +72,15 @@
 
   border-radius: 4px;
   border: 0.824px solid var(--60, #585858);
+}
 
-  background: var(--Basic-White, #fff);
-
+.activatedBtn {
+  background-color: #fff;
+  color: #1a1a1a;
   cursor: pointer;
 }
 
-.cursorPointer {
-  cursor: pointer;
+.defaultBtn {
+  background-color: transparent;
+  color: #c6c6c6;
 }

--- a/src/app/_component/domain/addarticle/Titlebox.tsx
+++ b/src/app/_component/domain/addarticle/Titlebox.tsx
@@ -1,29 +1,41 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import styles from "./Titlebox.module.css";
 
-const Titlebox = () => {
-  const [title, setTitle] = useState("");
+interface Props {
+  title: string;
+  setTitle: (val: string) => void;
+  markdown: string;
+}
 
-  useEffect(() => {
-    const savedTitle = localStorage.getItem("draft-title");
-    if (savedTitle) setTitle(savedTitle);
-  }, []);
-
-  // 입력할 때마다 로컬 저장
+const Titlebox = ({ title, setTitle, markdown }: Props) => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newTitle = e.target.value;
     setTitle(newTitle);
     localStorage.setItem("draft-title", newTitle);
   };
 
+  const isReady = title.trim() !== "" && markdown.trim() !== "";
+
   return (
     <div className={styles.topContainer}>
       <div className={styles.container}>
         <p className={styles.title}>제목</p>
-        <input type="text" value={title} onChange={handleChange} className={styles.inputBox} />
+        <input
+          type="text"
+          value={title}
+          onChange={handleChange}
+          className={styles.inputBox}
+          placeholder="제목을 입력해주세요."
+        />
       </div>
       <div className={styles.buttonSection}>
-        <button type="button">생성하기</button>
+        <button
+          type="button"
+          className={isReady ? styles.activatedBtn : styles.defaultBtn}
+          disabled={!isReady}
+        >
+          생성하기
+        </button>
       </div>
     </div>
   );

--- a/src/app/_component/domain/addarticle/Titlebox.tsx
+++ b/src/app/_component/domain/addarticle/Titlebox.tsx
@@ -5,9 +5,10 @@ interface Props {
   title: string;
   setTitle: (val: string) => void;
   markdown: string;
+  onSubmit: () => void;
 }
 
-const Titlebox = ({ title, setTitle, markdown }: Props) => {
+const Titlebox = ({ title, setTitle, markdown, onSubmit }: Props) => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newTitle = e.target.value;
     setTitle(newTitle);
@@ -33,6 +34,7 @@ const Titlebox = ({ title, setTitle, markdown }: Props) => {
           type="button"
           className={isReady ? styles.activatedBtn : styles.defaultBtn}
           disabled={!isReady}
+          onClick={onSubmit}
         >
           생성하기
         </button>

--- a/src/app/_component/domain/addarticle/Titlebox.tsx
+++ b/src/app/_component/domain/addarticle/Titlebox.tsx
@@ -1,12 +1,26 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styles from "./Titlebox.module.css";
 
 const Titlebox = () => {
+  const [title, setTitle] = useState("");
+
+  useEffect(() => {
+    const savedTitle = localStorage.getItem("draft-title");
+    if (savedTitle) setTitle(savedTitle);
+  }, []);
+
+  // 입력할 때마다 로컬 저장
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newTitle = e.target.value;
+    setTitle(newTitle);
+    localStorage.setItem("draft-title", newTitle);
+  };
+
   return (
     <div className={styles.topContainer}>
       <div className={styles.container}>
         <p className={styles.title}>제목</p>
-        <input type="text" className={styles.inputBox} />
+        <input type="text" value={title} onChange={handleChange} className={styles.inputBox} />
       </div>
       <div className={styles.buttonSection}>
         <button type="button">생성하기</button>

--- a/src/app/_component/domain/addarticle/ToastEditor.tsx
+++ b/src/app/_component/domain/addarticle/ToastEditor.tsx
@@ -4,17 +4,23 @@ import { Editor } from "@toast-ui/react-editor";
 import "@toast-ui/editor/dist/toastui-editor.css";
 import styles from "./ToastEditor.module.css";
 
-const ToastEditor = () => {
+interface Props {
+  setMarkdown: (val: string) => void;
+}
+
+const ToastEditor = ({ setMarkdown }: Props) => {
   const editorRef = useRef<Editor>(null);
 
   useEffect(() => {
     const savedMarkdown = localStorage.getItem("draft-markdown");
     const instance = editorRef.current?.getInstance();
     instance?.setMarkdown(savedMarkdown || "");
+    setMarkdown(savedMarkdown || "");
 
     const handleChange = () => {
       const md = instance?.getMarkdown() || "";
       localStorage.setItem("draft-markdown", md);
+      setMarkdown(md);
     };
 
     instance?.on("change", handleChange);
@@ -22,13 +28,13 @@ const ToastEditor = () => {
     return () => {
       instance?.off("change", handleChange);
     };
-  }, []);
+  }, [setMarkdown]);
 
   return (
     <div className={styles.editorWrapper}>
       <Editor
         ref={editorRef}
-        placeholder="내용을 작성하세요"
+        placeholder="내용을 작성해주세요."
         previewStyle="vertical"
         height="40rem"
         initialEditType="markdown"

--- a/src/app/_component/domain/addarticle/ToastEditor.tsx
+++ b/src/app/_component/domain/addarticle/ToastEditor.tsx
@@ -8,8 +8,20 @@ const ToastEditor = () => {
   const editorRef = useRef<Editor>(null);
 
   useEffect(() => {
+    const savedMarkdown = localStorage.getItem("draft-markdown");
     const instance = editorRef.current?.getInstance();
-    instance?.setMarkdown(""); // 본문 비우기
+    instance?.setMarkdown(savedMarkdown || "");
+
+    const handleChange = () => {
+      const md = instance?.getMarkdown() || "";
+      localStorage.setItem("draft-markdown", md);
+    };
+
+    instance?.on("change", handleChange);
+
+    return () => {
+      instance?.off("change", handleChange);
+    };
   }, []);
 
   return (

--- a/src/app/_component/domain/readArticle/ReadArticleModal.module.css
+++ b/src/app/_component/domain/readArticle/ReadArticleModal.module.css
@@ -67,20 +67,6 @@
   margin: 0 1rem;
 }
 
-.bodySection h1 {
-  font-size: 2.2rem;
-  font-style: normal;
-  font-weight: 400;
-  line-height: normal;
-}
-
-.bodySection p {
-  font-size: 1.2rem;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 20px;
-}
-
 .deleteIc {
   cursor: pointer;
 }

--- a/src/app/_component/domain/readArticle/ReadArticleModal.module.css
+++ b/src/app/_component/domain/readArticle/ReadArticleModal.module.css
@@ -62,7 +62,8 @@
   justify-content: center;
 
   color: var(--Basic-Black, #000);
-
+  line-height: 22px;
+  font-size: 1.2rem;
   gap: 1rem;
   margin: 0 1rem;
 }
@@ -73,4 +74,8 @@
 
 .deleteIc > path {
   stroke: #000000;
+}
+
+.tui-editor-contents {
+  color: #000;
 }

--- a/src/app/_component/domain/readArticle/ReadArticleModal.tsx
+++ b/src/app/_component/domain/readArticle/ReadArticleModal.tsx
@@ -1,34 +1,71 @@
 "use client";
-import React from "react";
+
+import React, { useEffect, useState } from "react";
 import styles from "./ReadArticleModal.module.css";
 import ICDelete from "@/assets/icon/delete.svg";
 import ReactMarkdown from "react-markdown";
 import { useModalStore } from "@/store/useModalStore";
+import { doc, getDoc } from "firebase/firestore";
+import fireStore from "@/firebase/firestore";
 
-const ReadArticleModal = () => {
+interface Props {
+  studyRoomId: string;
+  articleId: string;
+}
+
+const ReadArticleModal = ({ studyRoomId, articleId }: Props) => {
   const close = useModalStore(state => state.close);
 
-  const markdownText = `
-  # 테스트
-  `;
-  return (
-    <>
-      <div className={styles.overlay}>
-        <div className={styles.modalBox}>
-          <div className={styles.topSection}>
-            <div>
-              <h1>Article 읽기</h1>
-              <h2>12기 박지효 | 25.02.11</h2>
-            </div>
+  const [articleData, setArticleData] = useState<{
+    title: string;
+    creatorName: string;
+    creatorYear: string;
+    content: string;
+    createdAt?: any;
+  } | null>(null);
 
-            <ICDelete className={styles.deleteIc} onClick={close} />
+  useEffect(() => {
+    const fetchArticle = async () => {
+      try {
+        const articleRef = doc(fireStore, "studyRooms", studyRoomId, "articles", articleId);
+        const articleSnap = await getDoc(articleRef);
+
+        if (articleSnap.exists()) {
+          setArticleData(articleSnap.data() as any);
+        } else {
+          console.error("해당 아티클을 찾을 수 없습니다.");
+        }
+      } catch (error) {
+        console.error("아티클 불러오기 실패:", error);
+      }
+    };
+
+    fetchArticle();
+  }, [studyRoomId, articleId]);
+
+  if (!articleData) return <div className={styles.overlay}>로딩 중...</div>;
+
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.modalBox}>
+        <div className={styles.topSection}>
+          <div>
+            <h1>{articleData.title}</h1>
+            <h2>
+              {articleData.creatorYear}기 {articleData.creatorName} |{" "}
+              {articleData.createdAt
+                ? new Date(articleData.createdAt.seconds * 1000).toLocaleDateString("ko-KR")
+                : " "}
+            </h2>
           </div>
-          <div className={styles.bodySection}>
-            <ReactMarkdown>{markdownText}</ReactMarkdown>
-          </div>
+
+          <ICDelete className={styles.deleteIc} onClick={close} />
+        </div>
+        <div className={styles.bodySection}>
+          <ReactMarkdown>{articleData.content}</ReactMarkdown>
         </div>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/app/_component/domain/readArticle/ReadArticleModal.tsx
+++ b/src/app/_component/domain/readArticle/ReadArticleModal.tsx
@@ -1,12 +1,19 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import styles from "./ReadArticleModal.module.css";
-import ICDelete from "@/assets/icon/delete.svg";
-import ReactMarkdown from "react-markdown";
+import dynamic from "next/dynamic";
+
 import { useModalStore } from "@/store/useModalStore";
-import { doc, getDoc } from "firebase/firestore";
 import fireStore from "@/firebase/firestore";
+import { doc, getDoc } from "firebase/firestore";
+
+import ICDelete from "@/assets/icon/delete.svg";
+
+import styles from "./ReadArticleModal.module.css";
+
+const Viewer = dynamic(() => import("@toast-ui/react-editor").then(mod => mod.Viewer), {
+  ssr: false
+});
 
 interface Props {
   studyRoomId: string;
@@ -62,7 +69,7 @@ const ReadArticleModal = ({ studyRoomId, articleId }: Props) => {
           <ICDelete className={styles.deleteIc} onClick={close} />
         </div>
         <div className={styles.bodySection}>
-          <ReactMarkdown>{articleData.content}</ReactMarkdown>
+          <Viewer key={articleData?.content} initialValue={articleData?.content || ""} />
         </div>
       </div>
     </div>

--- a/src/app/_component/domain/readArticle/ReadArticleModal.tsx
+++ b/src/app/_component/domain/readArticle/ReadArticleModal.tsx
@@ -1,8 +1,13 @@
+"use client";
 import React from "react";
 import styles from "./ReadArticleModal.module.css";
 import ICDelete from "@/assets/icon/delete.svg";
 import ReactMarkdown from "react-markdown";
+import { useModalStore } from "@/store/useModalStore";
+
 const ReadArticleModal = () => {
+  const close = useModalStore(state => state.close);
+
   const markdownText = `
   # 테스트
   `;
@@ -16,11 +21,9 @@ const ReadArticleModal = () => {
               <h2>12기 박지효 | 25.02.11</h2>
             </div>
 
-            <ICDelete className={styles.deleteIc} />
+            <ICDelete className={styles.deleteIc} onClick={close} />
           </div>
           <div className={styles.bodySection}>
-            <h1>1주차 - 마크다운이란?</h1>
-
             <ReactMarkdown>{markdownText}</ReactMarkdown>
           </div>
         </div>


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버

<!-- ex) close #1 -->
close #30  #32 
## ✅ 작업 목록

<!-- 이슈 작업한 내용 -->
### 1. 아티클 작성 중단 모달 구현
- 중첩 모달 사용하지 않고 작성중인 데이터 저장 후 다시 불러오는 방식 채택했습니다.
- 새로고침해도(모달 닫혔다가 다시 열려도) 저장되고 불러올 수 있도록 로컬스토리지에 저장해뒀고, 중단하기 버튼 or 생성하기 버튼을 누르면 로컬스토리지에서 삭제되도록 했습니다


### 2. 생성하기 버튼 활성화
- 제목, 내용 둘 다 작성되어야만 생성하기 버튼이 활성화되도록 수정했습니다.
- 이 부분은 추후 토스트 기능까지 연결할 예정입니다.

### 3. 아티클 작성/읽기 파이어베이스 연동
- 현재의 `studyroomId`, `articleId` 불러오기 기능 추가적으로 구현해야합니다.
- 지금은 둘 다 하드코딩해뒀습니다..!

### 4. 아티클 읽기 모달 마크다운 라이브러리 변경
- 기존에는 `react-markdown`을 사용했었으나, 표 등 다양한 기능을 사용하기 위해서는 따로 설정을 해주어야 합니다.
- 하나하나 설정하는 것보다는 `승현님😽`이 언급하신 toast-ui의 Viewer을 사용하는 것이 합리적이라고 생각되어 변경했습니다.
``` 
const Viewer = dynamic(() => import("@toast-ui/react-editor").then(mod => mod.Viewer), {
  ssr: false
});
```
-> 동일하게 dynamic처리 했습니다!

### 5. 아티클 페이지 빌드 에러 해결
폴더 구조 변경하고 import문에 수정을 안 해서 생긴 에러였습니다..😅

## 🍰 논의사항

<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->
### `articleId` 가져오는 방식
studyRoom에서 articles 데이터를 가져올 때 `articleId`도 같이 가져오게 되는데, 
 `ReadArticleModal`를 열 때 id를 프로퍼티로 보내주는 방식으로 하면 될까요?


## 📷 ETC

<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
<아티클 작성 및 읽기 모달>

https://github.com/user-attachments/assets/c0e4ccdf-8eca-48a8-a1e6-67cda9215603

<아티클 작성 중단 모달>

https://github.com/user-attachments/assets/22168ae0-bdb7-4a66-940e-360792fb265e

