### PR TITLE
Fix: 모달 뒤로가기, 새로고침 방지

### DIFF
--- a/src/app/_component/common/Modal.tsx
+++ b/src/app/_component/common/Modal.tsx
@@ -6,8 +6,11 @@ import { useModalStore } from "@/store/useModalStore";
 import { createPortal } from "react-dom";
 import { useIsMounted } from "@/hooks/useIsMounted";
 import { useToastStore } from "@/store/useToastStore";
+import { useConfirmBeforeRefresh } from "@/hooks/useConfirmBeforeRefresh";
 
 export default function Modal() {
+  useConfirmBeforeRefresh(); // 새로고침 방지
+
   const { showToast } = useToastStore();
   const isMounted = useIsMounted();
 

--- a/src/app/_component/common/Modal.tsx
+++ b/src/app/_component/common/Modal.tsx
@@ -5,8 +5,10 @@ import modalStyles from "@/app/_component/common/Modal.module.css";
 import { useModalStore } from "@/store/useModalStore";
 import { createPortal } from "react-dom";
 import { useIsMounted } from "@/hooks/useIsMounted";
+import { useToastStore } from "@/store/useToastStore";
 
 export default function Modal() {
+  const { showToast } = useToastStore();
   const isMounted = useIsMounted();
 
   // 전역 모달 상태를 가져옴
@@ -26,7 +28,29 @@ export default function Modal() {
     };
   }, [isOpen]);
 
-  if (!isMounted || !isOpen) return null;
+  // if (!isMounted || !isOpen) return null;
+
+  // 모달 열릴 때 뒤로가기 방지
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const pushState = () => {
+      window.history.pushState(null, "", window.location.href);
+    };
+
+    const handlePopState = (e: PopStateEvent) => {
+      e.preventDefault();
+      pushState();
+      showToast("goBack");
+    };
+
+    pushState(); // 모달 열릴 때 한 번 push
+    window.addEventListener("popstate", handlePopState);
+
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, [isOpen]);
 
   // 모달 backdrop 클릭 시 모달 닫음
   const handleClickOutside = (e: MouseEvent<HTMLDivElement>) => {
@@ -41,7 +65,7 @@ export default function Modal() {
   };
 
   // 모달이 열려있지 않거나 서버에서 실행되는 경우를 차단
-  if (!isOpen || typeof window === "undefined") return null;
+  if (!isMounted || !isOpen || typeof window === "undefined") return null;
 
   // Portal을 생성하고 내부에서 모달 content를 렌더링
   return createPortal(

--- a/src/app/_component/domain/addarticle/AddArticleModal.tsx
+++ b/src/app/_component/domain/addarticle/AddArticleModal.tsx
@@ -114,8 +114,8 @@ const AddArticleModal = ({ articleId }: Props) => {
   };
 
   return (
-    <div className={styles.overlay}>
-      <div className={styles.modalBox}>
+    <div className={styles.overlay} onClick={handleOpenDelete}>
+      <div className={styles.modalBox} onClick={e => e.stopPropagation()}>
         <div className={styles.topSection}>
           <p>{articleId ? "Article 수정하기" : "Article 생성하기"}</p>
           <ICDelete onClick={handleOpenDelete} style={{ cursor: "pointer" }} />

--- a/src/constants/ToastTypeList.ts
+++ b/src/constants/ToastTypeList.ts
@@ -111,6 +111,12 @@ export const ToastTypeList: ToastItem[] = [
     subtitle: "",
     color: "green"
   },
+  {
+    type: "goBack",
+    title: "작성 중에는 뒤로갈 수 없습니다.",
+    subtitle: "",
+    color: "yellow"
+  },
 
   // empty
   {

--- a/src/hooks/useConfirmBeforeRefresh.ts
+++ b/src/hooks/useConfirmBeforeRefresh.ts
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+
+export const useConfirmBeforeRefresh = () => {
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, []);
+};


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🚀 feature 기능 추가
- [x] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버

<!-- ex) close #1 -->
#67 

## ✅ 작업 목록
1. 모달 오픈 시 뒤로가기 방지
```
useEffect(() => {
    if (!isOpen) return;

    const pushState = () => {
      window.history.pushState(null, "", window.location.href);
    };

    const handlePopState = (e: PopStateEvent) => {
      e.preventDefault(); // ‼️기본 동작(페이지 이동) 막음
      pushState();
      showToast("goBack");
    };

    pushState(); // 모달 열릴 때 한 번 push
    window.addEventListener("popstate", handlePopState);

    return () => {
      window.removeEventListener("popstate", handlePopState);
    };
  }, [isOpen]);
```
`window.history.pushState()` :  브라우저의 히스토리 스택에 현재 URL을 새로운 항목으로 추가
뒤로가기를 누를 경우 히스토리 스택에 현재 페이지가 있으므로 뒤로가기가 눌리지 않음!

2. 모달 오픈 시 새로고침 확인창 생성
```
import { useEffect } from "react";

export const useConfirmBeforeRefresh = () => {
  useEffect(() => {
    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
      e.preventDefault(); // ‼️ 기본 동작(새로고침) 막음
      e.returnValue = ""; // ‼️ 브라우저에서 제공하는 기본 확인창을 띄움
    };

    window.addEventListener("beforeunload", handleBeforeUnload);

    return () => {
      window.removeEventListener("beforeunload", handleBeforeUnload);
    };
  }, []);
};

```
-> 추후 리팩토링하기 쉽게 훅으로 만들어 사용했습니다


3. 아티클 작성 모달 오버레이 클릭 시 작성 중단 모달 생성
<!-- 이슈 작업한 내용 -->

## 🍰 논의사항

<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->
실수로 이전 브랜치에 작업해 버렸네요.. 호호...~

새로고침 기능은 추후 임시저장 기능과 함께 리팩토링 예정입니다!

## 📷 ETC

<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->

https://github.com/user-attachments/assets/b6cd8b81-aeee-4574-b708-38cf8b365861


