### PR TITLE
Feat: UI 항목 이슈 작업

### DIFF
--- a/src/app/_component/domain/login/modal/LogoutModalContent.tsx
+++ b/src/app/_component/domain/login/modal/LogoutModalContent.tsx
@@ -7,14 +7,17 @@ import { signOutWithGoogle } from "@/firebase/firebaseAuth";
 import ICDelete from "@/assets/icon/delete.svg";
 import modalStyles from "@/app/_component/common/Modal.module.css";
 import styles from "./LogoutModal.module.css";
+import { useToastStore } from "@/store/useToastStore";
 
 export default function LogoutModalContent() {
   const { name, year, part, clearUser } = useUserStore();
   const close = useModalStore(state => state.close);
+  const showToast = useToastStore(state => state.showToast);
 
   const handleLogout = async () => {
     await signOutWithGoogle();
     clearUser();
+    showToast("logout");
     close();
   };
 

--- a/src/app/_component/domain/login/modal/SignUpModalContent.tsx
+++ b/src/app/_component/domain/login/modal/SignUpModalContent.tsx
@@ -9,6 +9,7 @@ import { useState } from "react";
 import modalStyles from "@/app/_component/common/Modal.module.css";
 import styles from "./SignUpModal.module.css";
 import PlusBtn from "@/app/_component/common/PlusBtn";
+import { useToastStore } from "@/store/useToastStore";
 
 const PART_OPTIONS = [
   { value: "기획", label: "기획" },
@@ -24,8 +25,10 @@ export default function SignUpModalContent({
   uid: string | null;
   googleId: string | null;
 }) {
+  const showToast = useToastStore(state => state.showToast);
+
   if (!uid || !googleId) {
-    alert("로그인을 다시 해주세요.");
+    showToast("signup_error");
     return null;
   }
 
@@ -37,7 +40,7 @@ export default function SignUpModalContent({
   const isFormValid = name && year && part;
 
   const handleSubmit = async () => {
-    if (!isFormValid) return alert("모든 값을 입력하세요");
+    if (!isFormValid) return showToast("signup_empty");
 
     await setDoc(doc(fireStore, "users", uid), {
       googleId,

--- a/src/app/_component/domain/main/AddStudyContent.module.css
+++ b/src/app/_component/domain/main/AddStudyContent.module.css
@@ -23,6 +23,7 @@
   border-radius: 4px;
   border: 1px solid #c6c6c6;
   background: #fff;
+  font-family: "Pretendard";
 
   outline: none;
 }

--- a/src/app/_component/domain/main/AddStudyContent.tsx
+++ b/src/app/_component/domain/main/AddStudyContent.tsx
@@ -143,7 +143,14 @@ export default function AddStudyContent() {
           <PlusBtn
             text="생성하기"
             state={studyName.trim() ? "active" : "default"}
-            onClick={handleSubmit}
+            onClick={() => {
+              if (!studyName.trim()) {
+                showToast("emptyTitle");
+                return;
+              }
+              handleSubmit();
+              showToast("addStudyroom");
+            }}
           />
         </div>
       </div>

--- a/src/app/_component/domain/main/AddStudyContent.tsx
+++ b/src/app/_component/domain/main/AddStudyContent.tsx
@@ -19,10 +19,12 @@ import PlusBtn from "../../common/PlusBtn";
 
 import modalStyles from "@/app/_component/common/Modal.module.css";
 import styles from "./AddStudyContent.module.css";
+import { useToastStore } from "@/store/useToastStore";
 
 export default function AddStudyContent() {
   const { name, year } = useUserStore();
   const { isLoggedIn } = useAuth();
+  const showToast = useToastStore(state => state.showToast);
   const close = useModalStore(state => state.close);
   const fetchStudyRooms = useStudyRoomStore(state => state.fetchStudyRooms);
 
@@ -61,7 +63,7 @@ export default function AddStudyContent() {
 
       // 사용자 인증 확인
       if (!isLoggedIn) {
-        alert("로그인이 필요합니다.");
+        showToast("login");
         return;
       }
 
@@ -73,7 +75,7 @@ export default function AddStudyContent() {
           imageUrl = await getDownloadURL(storageRef);
         } catch (uploadError) {
           console.error("이미지 업로드 중 오류 발생:", uploadError);
-          alert("이미지 업로드에 실패했습니다. 다시 시도해주세요.");
+          showToast("fail_add_image");
           return;
         }
       }
@@ -91,7 +93,7 @@ export default function AddStudyContent() {
       close();
     } catch (error) {
       console.error("서재 생성 중 오류 발생:", error);
-      alert("서재 생성에 실패했습니다. 다시 시도해주세요.");
+      showToast("fail_add_studyroom");
     }
   };
 

--- a/src/app/_component/domain/main/StudyBtn.module.css
+++ b/src/app/_component/domain/main/StudyBtn.module.css
@@ -48,7 +48,7 @@
   flex-direction: column;
 
   gap: 0.7rem;
-  padding: 0.8rem 1.592rem 0rem 1.592rem;
+  padding: 1rem 1.592rem 0rem 1rem;
   width: 100%;
   height: 6.8rem;
 
@@ -98,6 +98,12 @@
 }
 
 .heartWrapper {
+  width: 2.4rem;
+  height: 2.4rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
   z-index: 1;
 }
 

--- a/src/app/_component/studyroom/StudyroomMain.module.css
+++ b/src/app/_component/studyroom/StudyroomMain.module.css
@@ -1,6 +1,6 @@
 .mainContainer {
   width: 100vw;
-  height: 100vh;
+  height: auto;
 
   display: grid;
   grid-template-columns: 1fr 2fr;

--- a/src/constants/ToastTypeList.ts
+++ b/src/constants/ToastTypeList.ts
@@ -31,6 +31,32 @@ export const ToastTypeList: ToastItem[] = [
     subtitle: "",
     color: "green"
   },
+  {
+    type: "login_error",
+    title: "로그인에 실패했습니다.",
+    subtitle: "다시 로그인해주세요.",
+    color: "yellow"
+  },
+  {
+    type: "network_error",
+    title: "네트워크 오류",
+    subtitle: "인터넷 연결 상태를 확인해주세요.",
+    color: "yellow"
+  },
+
+  // signup
+  {
+    type: "signup_error",
+    title: "로그인을 다시 해주세요.",
+    subtitle: "",
+    color: "yellow"
+  },
+  {
+    type: "signup_empty",
+    title: "모든 값을 입력하세요.",
+    subtitle: "",
+    color: "yellow"
+  },
 
   // studyroom
   {
@@ -55,6 +81,18 @@ export const ToastTypeList: ToastItem[] = [
     type: "wrongStudyroomId",
     title: "스터디룸 ID가 유효하지 않습니다.",
     subtitle: "",
+    color: "yellow"
+  },
+  {
+    type: "fail_add_image",
+    title: "이미지 업로드에 실패했습니다.",
+    subtitle: "다시 시도해주세요.",
+    color: "yellow"
+  },
+  {
+    type: "fail_add_studyroom",
+    title: "서재 생성에 실패했습니다.",
+    subtitle: "다시 시도해주세요.",
     color: "yellow"
   },
 


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버

close #64

## ✅ 작업 목록
- 디자인 - 메인 페이지 하트 크기 변경
- 디자인 - 카드 텍스트 중앙 정렬
- 토스트 - alert에서 토스트로 변경
- 토스트 - 서재명 미입력 상태에서 생성하기 버튼 클릭 시 토스트

### ✨ 주요 변경 사항
#### 📁 `firebaseAuth.ts`
- `navigator.onLine`으로 브라우저 오프라인 상태 먼저 감지하도록 변경
- FirebaseError의 `error.code`에 따른 케이스 분기 처리
- 반환 타입 구조:
  ```ts
  type Result =
    | "existing"
    | { uid: string; email: string }
    | { error: "popup_closed" | "network_error" | "internal_error" };

#### 💻 `GoogleLoginBtn.tsx`
signInWithGoogle()의 결과에 따라 토스트 메시지 다르게 출력합니다.
popup_closed → showToast("login_error")
network_error → showToast("network_error")
internal_error → showToast("fail")
로그인 성공 시 유저 정보 저장 및 showToast("welcome") 호출합니다.
