### PR TITLE
feat : studyroom 무한 스크롤 구현

### DIFF
--- a/src/app/_component/studyroom/Article.module.css
+++ b/src/app/_component/studyroom/Article.module.css
@@ -2,7 +2,6 @@
   gap: 2rem;
 
   overflow-y: auto;
-  max-height: 40vh;
 }
 
 #articleSingleContainer {

--- a/src/app/_component/studyroom/Article.module.css
+++ b/src/app/_component/studyroom/Article.module.css
@@ -1,13 +1,21 @@
 #articleContainer {
   gap: 2rem;
+
+  overflow-y: auto;
+  max-height: 40vh;
 }
 
 #articleSingleContainer {
+  width: 100%;
   padding: 2rem;
 
   gap: 2.4rem;
 
   cursor: pointer;
+}
+
+#lastArticleContainer {
+  width: 100%;
 }
 
 .articleTitle {

--- a/src/app/_component/studyroom/Article.tsx
+++ b/src/app/_component/studyroom/Article.tsx
@@ -119,7 +119,10 @@ const Article = () => {
         <div>Article</div>
         <AddSubContentBtn type={SUB_CONTENT_TYPE.ARTICLE} />
       </div>
-      <div className={commonStyles.contentItem} id={style.articleContainer}>
+      <div
+        className={articles.length == 0 ? commonStyles.noItemWrapper : commonStyles.scrollContainer}
+        id={style.articleContainer}
+      >
         {articles.length !== 0 ? (
           articles.slice(0, visibleCount).map((item, index) => {
             const isLastItem = index === visibleCount - 1;

--- a/src/app/_component/studyroom/Article.tsx
+++ b/src/app/_component/studyroom/Article.tsx
@@ -114,7 +114,7 @@ const Article = () => {
   };
 
   return (
-    <div className={commonStyles.contentContainer}>
+    <div className={commonStyles.contentContainer} id={commonStyles.bottomContentContainer}>
       <div className={commonStyles.contentTitle}>
         <div>Article</div>
         <AddSubContentBtn type={SUB_CONTENT_TYPE.ARTICLE} />

--- a/src/app/_component/studyroom/CommonStyles.module.css
+++ b/src/app/_component/studyroom/CommonStyles.module.css
@@ -12,6 +12,14 @@
   background: rgba(255, 255, 255, 0.06);
 }
 
+#topContentContainer {
+  min-height: 25%;
+}
+
+#bottomContentContainer {
+  min-height: 80%;
+}
+
 .contentTitle {
   width: 100%;
 
@@ -52,7 +60,10 @@
   display: flex;
   width: 100%;
   flex-direction: column;
-  align-items: flex-start;
+  justify-content: center;
+  align-items: center;
+
+  flex-grow: 1;
 }
 
 .contentSingleItem {

--- a/src/app/_component/studyroom/CommonStyles.module.css
+++ b/src/app/_component/studyroom/CommonStyles.module.css
@@ -13,11 +13,12 @@
 }
 
 #topContentContainer {
-  min-height: 25%;
+  min-height: 14rem;
+  max-height: 20rem;
 }
 
 #bottomContentContainer {
-  min-height: 80%;
+  height: 45rem;
 }
 
 .contentTitle {
@@ -56,14 +57,18 @@
   line-height: 2.4471rem;
 }
 
-.contentItem {
-  display: flex;
-  width: 100%;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+.scrollContainer {
+  overflow-y: hidden;
 
-  flex-grow: 1;
+  display: flex;
+}
+
+.scrollContainer {
+  width: 100%;
+  overflow-y: hidden;
+
+  display: flex;
+  flex-direction: column;
 }
 
 .contentSingleItem {
@@ -130,6 +135,13 @@
 
 #infoContent {
   display: flex;
+}
+
+.noItemWrapper {
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .noItemContainer {

--- a/src/app/_component/studyroom/Link.module.css
+++ b/src/app/_component/studyroom/Link.module.css
@@ -6,6 +6,8 @@
   justify-content: flex-start;
   flex-wrap: wrap;
   gap: 1rem;
+
+  overflow-y: auto;
 }
 
 #linkSingleContainer {

--- a/src/app/_component/studyroom/Link.tsx
+++ b/src/app/_component/studyroom/Link.tsx
@@ -66,23 +66,25 @@ const Link = () => {
         <div>Link</div>
         <AddSubContentBtn type={SUB_CONTENT_TYPE.LINK} />
       </div>
-      <div id={style.linkContainer}>
-        {links.length != 0 ? (
-          links.map((item, key) => (
-            <LinkItem
-              key={key}
-              handleDelete={handleDelete}
-              handleClickLink={handleClickLink}
-              id={item.id}
-              title={item.title}
-              url={item.url}
-            />
-          ))
-        ) : (
-          <div className={commonStyles.noItemContainer}>
-            <div className={commonStyles.noItemText}>Link를 생성해주세요.</div>
-          </div>
-        )}
+      <div className={commonStyles.scrollContainer}>
+        <div id={style.linkContainer}>
+          {links.length != 0 ? (
+            links.map((item, key) => (
+              <LinkItem
+                key={key}
+                handleDelete={handleDelete}
+                handleClickLink={handleClickLink}
+                id={item.id}
+                title={item.title}
+                url={item.url}
+              />
+            ))
+          ) : (
+            <div className={commonStyles.noItemContainer}>
+              <div className={commonStyles.noItemText}>Link를 생성해주세요.</div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/app/_component/studyroom/Link.tsx
+++ b/src/app/_component/studyroom/Link.tsx
@@ -61,7 +61,7 @@ const Link = () => {
 
   if (!links) return <div>로딩 중..</div>;
   return (
-    <div className={commonStyles.contentContainer}>
+    <div className={commonStyles.contentContainer} id={commonStyles.topContentContainer}>
       <div className={commonStyles.contentTitle}>
         <div>Link</div>
         <AddSubContentBtn type={SUB_CONTENT_TYPE.LINK} />

--- a/src/app/_component/studyroom/Notice.module.css
+++ b/src/app/_component/studyroom/Notice.module.css
@@ -1,11 +1,18 @@
 #noticeContainer {
   gap: 1rem;
+
+  overflow-y: auto;
+  max-height: 40vh;
 }
 
 #noticeSingleContainer {
   padding: 1rem 1.4rem;
 
   gap: 1.4rem;
+}
+
+#lastNoticeContainer {
+  width: 100%;
 }
 
 .noticeTitle {

--- a/src/app/_component/studyroom/Notice.tsx
+++ b/src/app/_component/studyroom/Notice.tsx
@@ -106,7 +106,10 @@ const Notice = () => {
         <div>Notice</div>
         <AddSubContentBtn type={SUB_CONTENT_TYPE.NOTICE} />
       </div>
-      <div className={commonStyles.contentItem} id={style.noticeContainer}>
+      <div
+        className={notices.length == 0 ? commonStyles.noItemWrapper : commonStyles.scrollContainer}
+        id={style.noticeContainer}
+      >
         {notices.length !== 0 ? (
           notices.slice(0, visibleCount).map((item, index) => {
             const isLastItem = index === visibleCount - 1;

--- a/src/app/_component/studyroom/Notice.tsx
+++ b/src/app/_component/studyroom/Notice.tsx
@@ -101,7 +101,7 @@ const Notice = () => {
   };
 
   return (
-    <div className={commonStyles.contentContainer}>
+    <div className={commonStyles.contentContainer} id={commonStyles.bottomContentContainer}>
       <div className={commonStyles.contentTitle}>
         <div>Notice</div>
         <AddSubContentBtn type={SUB_CONTENT_TYPE.NOTICE} />

--- a/src/app/_component/studyroom/Notice.tsx
+++ b/src/app/_component/studyroom/Notice.tsx
@@ -10,7 +10,7 @@ import { useUserStore } from "@/store/useUserStore";
 import { NoticeItem as NoticeItemProp } from "@/types/studyRoomDetails/notice";
 import { formatDate } from "@/utils/formatDate";
 import { StudyroomItemButtonHandler } from "@/types/studyRoomDetails/itemClickHandler";
-import { useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import AddNoticeModalContent from "./modal/AddNoticeContentModal";
 import { useModalStore } from "@/store/useModalStore";
 import DeleteContentModal from "./modal/DeleteContentModal";
@@ -62,7 +62,24 @@ const Notice = () => {
   const user = useUserStore();
   const id = useStudyroomIdStore(state => state.studyroomId);
 
-  const { notices, createNotice, updateNotice, deleteNotice } = useNotices(id ?? "");
+  const { notices } = useNotices(id ?? "");
+
+  const [visibleCount, setVisibleCount] = useState(5); // 처음 10개만 보여줌
+  const observer = useRef<IntersectionObserver | null>(null);
+
+  const lastNoticeRef = useCallback((node: HTMLDivElement | null) => {
+    if (observer.current) observer.current.disconnect();
+
+    observer.current = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting) {
+        setTimeout(() => {
+          setVisibleCount(prev => prev + 5); // 300ms 딜레이 후 5개 추가
+        }, 300);
+      }
+    });
+
+    if (node) observer.current.observe(node);
+  }, []);
 
   if (!notices) return <div>로딩 중..</div>;
 
@@ -90,16 +107,33 @@ const Notice = () => {
         <AddSubContentBtn type={SUB_CONTENT_TYPE.NOTICE} />
       </div>
       <div className={commonStyles.contentItem} id={style.noticeContainer}>
-        {notices.length != 0 ? (
-          notices.map((item, key) => (
-            <NoticeItem
-              key={key}
-              noticeProps={item}
-              handleDelete={handleDelete}
-              handleUpdate={handleUpdate}
-              isMyNotice={item.creatorId == user.uid}
-            />
-          ))
+        {notices.length !== 0 ? (
+          notices.slice(0, visibleCount).map((item, index) => {
+            const isLastItem = index === visibleCount - 1;
+
+            if (isLastItem) {
+              return (
+                <div ref={lastNoticeRef} key={item.id} id={style.lastNoticeContainer}>
+                  <NoticeItem
+                    noticeProps={item}
+                    handleDelete={handleDelete}
+                    handleUpdate={handleUpdate}
+                    isMyNotice={item.creatorId == user.uid}
+                  />
+                </div>
+              );
+            } else {
+              return (
+                <NoticeItem
+                  key={item.id}
+                  noticeProps={item}
+                  handleDelete={handleDelete}
+                  handleUpdate={handleUpdate}
+                  isMyNotice={item.creatorId == user.uid}
+                />
+              );
+            }
+          })
         ) : (
           <div className={commonStyles.noItemContainer}>
             <div className={commonStyles.noItemText}>Notice를 생성해주세요.</div>

--- a/src/app/_component/studyroom/StudyroomTitle.module.css
+++ b/src/app/_component/studyroom/StudyroomTitle.module.css
@@ -5,6 +5,8 @@
 
 #mainBg {
   background: linear-gradient(275deg, rgba(26, 26, 26, 0.4) 0%, rgba(0, 52, 148, 0.4) 100%);
+
+  min-height: 25%;
 }
 
 .svgContainer {

--- a/src/app/_component/studyroom/StudyroomTitle.module.css
+++ b/src/app/_component/studyroom/StudyroomTitle.module.css
@@ -6,7 +6,7 @@
 #mainBg {
   background: linear-gradient(275deg, rgba(26, 26, 26, 0.4) 0%, rgba(0, 52, 148, 0.4) 100%);
 
-  min-height: 25%;
+  height: 14rem;
 }
 
 .svgContainer {


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
#34 
<!-- ex) close #1 -->

## ✅ 작업 목록
Link, Article, Notice에 대해 컨텐츠가 늘어나면 스크롤할 수 있는 기능을 구현하였습니다.
Link는 무한 스크롤 적용보다는 일단 스크롤하는 방식을 택했습니다. (추후 리팩토링 가능하니 다른 분들 의견도 궁금합니다!)

### 무한 스크롤 구현 방법
```
const observer = useRef<IntersectionObserver | null>(null);
const lastArticleRef = useCallback((node: HTMLDivElement | null) => {
  if (observer.current) observer.current.disconnect();

  observer.current = new IntersectionObserver(entries => {
    if (entries[0].isIntersecting) {
      setTimeout(() => {
        setVisibleCount(prev => prev + 5); // 5개 더 보여줌
      }, 300); // 가짜 로딩 지연
    }
  });

  if (node) observer.current.observe(node);
}, []);
```
IntersectionObserver를 생성하고, 마지막 아이템이 뷰포트에 들어오면 visibleCount를 증가시켜 더 많은 게시글을 보여주도록 하였습니다.

```
const isLastItem = index === visibleCount - 1;

if (isLastItem) {
  return (
    <div ref={lastArticleRef} key={item.id}>
      <ArticleItem ... />
    </div>
  );
}
```
현재 렌더링 중인 게시글 중 마지막 요소에만 lastArticleRef를 연결해 다음 트리거 지점으로 설정하였습니다.

setTimeout은 UX상 로딩 효과를 주기 위한 지연 처리로, 현재는 데이터를 한번에 불러와 나누어 보여주는 방식을 택했으나 추후 리팩토링 가능합니다!

<!-- 이슈 작업한 내용 -->

## 🍰 논의사항

<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC
1. 컨텐츠가 꽉 찰 때
![화면-기록-2025-05-01-오전-20735](https://github.com/user-attachments/assets/c4f9acad-8949-484a-868c-bc1d274368ec)


2. 컨텐츠가 비어있을 때
<img width="1317" alt="스크린샷 2025-05-01 오전 2 04 34" src="https://github.com/user-attachments/assets/308f1f70-2b78-4d6b-96cc-c16f823dfaab" />



<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
