### PR TITLE
Style : 스터디룸 유효성 검사 버그 수정 및 스터디룸 레이아웃 개선

### DIFF
--- a/src/app/_component/studyroom/CommonStyles.module.css
+++ b/src/app/_component/studyroom/CommonStyles.module.css
@@ -13,12 +13,12 @@
 }
 
 #topContentContainer {
-  min-height: 14rem;
-  max-height: 20rem;
+  min-height: 20vh;
+  max-height: 25vh;
 }
 
 #bottomContentContainer {
-  height: 45rem;
+  height: 55vh;
 }
 
 .contentTitle {

--- a/src/app/_component/studyroom/StudyroomMain.tsx
+++ b/src/app/_component/studyroom/StudyroomMain.tsx
@@ -8,6 +8,7 @@ import Notice from "./Notice";
 import Link from "./Link";
 import Article from "./Article";
 import Toast from "../common/Toast";
+import Spinner from "../common/Spinner";
 
 import styles from "./StudyroomMain.module.css";
 import Ic_ArrowRight from "../../../assets/icon/arrow_right.svg";
@@ -70,6 +71,7 @@ const StudyroomMain = ({ id }: StudyRoomProps) => {
     return null;
   }
 
+  if (isLoading) return <Spinner />;
   return (
     <>
       <div className={styles.mainContainer}>

--- a/src/app/_component/studyroom/StudyroomMain.tsx
+++ b/src/app/_component/studyroom/StudyroomMain.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useEffect, useState } from "react";
 
-import { usePathname, useRouter } from "next/navigation";
+import { notFound, usePathname, useRouter } from "next/navigation";
 
 import StudyroomTitle from "./StudyroomTitle";
 import Notice from "./Notice";
@@ -48,9 +48,8 @@ const StudyroomMain = ({ id }: StudyRoomProps) => {
     const exists = studyRooms.some(room => room.id === id);
 
     if (!exists) {
-      showToast("wrongStudyroomId");
       clearId();
-      router.push("/");
+      notFound();
     } else {
       setId(id);
     }

--- a/src/app/_component/studyroom/StudyroomMain.tsx
+++ b/src/app/_component/studyroom/StudyroomMain.tsx
@@ -25,7 +25,6 @@ const StudyroomMain = ({ id }: StudyRoomProps) => {
   const router = useRouter();
 
   const { showToast, toastType } = useToastStore();
-
   const [showToastState, setShowToastState] = useState(false);
 
   // 클릭한 스터디룸 id값 관리
@@ -35,31 +34,31 @@ const StudyroomMain = ({ id }: StudyRoomProps) => {
 
   const { studyRooms, isLoading, fetchStudyRooms } = useStudyRoomStore();
 
+  // studyRooms 배열이 바뀌거나 id가 바뀌면 다시 받아오거나 기존 배열 사용
   useEffect(() => {
-    // 스터디룸 배열을 사용하여 유효한 스터디룸인지 확인하는 함수
-    const validate = async () => {
-      if (!isLoading && studyRooms.length === 0) {
-        // 만약 특정 스터디룸 링크로 바로 들어온 상태라면 fetch 해주어야 함.
-        await fetchStudyRooms();
-      }
+    if (studyRooms.length == 0) {
+      fetchStudyRooms();
+    }
+  }, [studyRooms, id]);
 
-      const exists = studyRooms.some(room => room.id === id);
+  // 2. isLoading이 끝난 후 유효성 검사
+  useEffect(() => {
+    if (isLoading) return;
 
-      if (!exists) {
-        showToast("wrongStudyroomId");
-        clearId();
-        router.push("/"); // 메인페이지로
-      } else {
-        setId(id);
-      }
-    };
+    const exists = studyRooms.some(room => room.id === id);
 
-    validate();
+    if (!exists) {
+      showToast("wrongStudyroomId");
+      clearId();
+      router.push("/");
+    } else {
+      setId(id);
+    }
 
     return () => {
       clearId();
     };
-  }, [id]);
+  }, [isLoading, studyRooms, id]);
 
   useEffect(() => {
     if (toastType) {

--- a/src/app/_component/studyroom/StudyroomTitle.module.css
+++ b/src/app/_component/studyroom/StudyroomTitle.module.css
@@ -6,7 +6,8 @@
 #mainBg {
   background: linear-gradient(275deg, rgba(26, 26, 26, 0.4) 0%, rgba(0, 52, 148, 0.4) 100%);
 
-  height: 14rem;
+  min-height: 20vh;
+  max-height: 25vh;
 }
 
 .svgContainer {

--- a/src/app/styles/not-found.module.css
+++ b/src/app/styles/not-found.module.css
@@ -8,7 +8,7 @@
   display: flex;
   flex-direction: column;
   gap: 5rem;
-  padding: 15rem 8rem 15rem 8rem;
+  padding: 15rem 8rem 10rem 8rem;
   background: linear-gradient(90deg, #1a1a1a 35.78%, #000 100%);
   position: absolute;
   width: 100vw;


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🚀 feature 기능 추가
- [x] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
close #80 
close #34 
<!-- ex) close #1 -->

## ✅ 작업 목록
1. 새로고침시 스터디룸 id를 인식하지 못하는 문제
이 문제는 전체 studyroom 배열을 불러오기 이전에 스터디룸 id의 유효성을 판단했기 때문에 발생하는 문제였습니다.
```ts
 // studyRooms 배열이 바뀌거나 id가 바뀌면 다시 받아오거나 기존 배열 사용
  useEffect(() => {
    if (studyRooms.length == 0) {
      fetchStudyRooms();
    }
  }, [studyRooms, id]);

  // 2. isLoading이 끝난 후 유효성 검사
  useEffect(() => {
    if (isLoading) return;

    const exists = studyRooms.some(room => room.id === id);

    if (!exists) {
      clearId();
      notFound();
    } else {
      setId(id);
    }

    return () => {
      clearId();
    };
  }, [isLoading, studyRooms, id]);
```
하나의 useEffect로 결과의 완전함을 보장할 수 없기 때문에, 다음과 같이 완전히 데이터를 받아온 후 유효성 검사를 하도록 useEffect를 2개 사용하여 구현했습니다.

2. 스피너 추가 및 404 페이지로 라우트
정보를 불러올 때 스피너 추가
잘못된 스터디룸 접근시 404 페이지로 라우트 thanks to @xionng ....

3. 스터디룸 레이아웃 변경
단위를 viewport 기준으로 변경하였습니다.

<!-- 이슈 작업한 내용 -->

## 🍰 논의사항

<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC

<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
