### PR TITLE
Refactor: 로딩 상태 개선 및 pagination 시 scroll 이동

### DIFF
--- a/src/app/_component/studyroom/Article.tsx
+++ b/src/app/_component/studyroom/Article.tsx
@@ -75,25 +75,6 @@ const ArticleItem = ({ articleProps, handleRead, isMyArticle }: ArticeItemInterf
             {articleProps.content}
           </div>
         </div>
-        {/* 아티클 수정, 삭제 */}
-        {/* <div className={commonStyles.flexSpaceBetContainer}>
-          {isMyArticle && (
-            <div className={commonStyles.btnContainer}>
-              <button
-                className={commonStyles.noticeBtn}
-                onClick={e => handleUpdate(e, articleProps.id)}
-              >
-                수정
-              </button>
-              <button
-                className={commonStyles.noticeBtn}
-                onClick={e => handleDelete(e, articleProps.id)}
-              >
-                삭제
-              </button>
-            </div>
-          )}
-        </div> */}
       </div>
     </div>
   );
@@ -126,6 +107,8 @@ const Article = () => {
   const handlePageChange = (page: number) => {
     if (page >= 1 && page <= totalPages) {
       setCurrentPage(page);
+
+      window.scrollTo({ top: 0, behavior: "smooth" });
     }
   };
 

--- a/src/app/_component/studyroom/Notice.tsx
+++ b/src/app/_component/studyroom/Notice.tsx
@@ -87,6 +87,8 @@ const Notice = () => {
   const handlePageChange = (page: number) => {
     if (page >= 1 && page <= totalPages) {
       setCurrentPage(page);
+
+      window.scrollTo({ top: 0, behavior: "smooth" });
     }
   };
 

--- a/src/app/_component/studyroom/StudyroomMain.tsx
+++ b/src/app/_component/studyroom/StudyroomMain.tsx
@@ -12,6 +12,9 @@ import styles from "./StudyroomMain.module.css";
 import Ic_ArrowRight from "../../../assets/icon/arrow_right.svg";
 import { useStudyroomIdStore } from "@/store/useStudyroomIdStore";
 import { useToastStore } from "@/store/useToastStore";
+import { useStudyroomDetail } from "@/hooks/useStudyroomDetail";
+import Loading from "@/app/loading";
+import NotFound from "@/app/not-found";
 
 // studyroom 메인 페이지
 const StudyroomMain = () => {
@@ -20,6 +23,7 @@ const StudyroomMain = () => {
 
   const { toastType } = useToastStore();
   const [showToastState, setShowToastState] = useState(false);
+  const { loading, error } = useStudyroomDetail(studyroomId ?? "");
 
   useEffect(() => {
     if (toastType) {
@@ -30,6 +34,9 @@ const StudyroomMain = () => {
   if (!studyroomId) {
     return null;
   }
+
+  if (loading) return <Loading />;
+  if (error) return <NotFound />;
 
   return (
     <>

--- a/src/app/_component/studyroom/StudyroomTitle.tsx
+++ b/src/app/_component/studyroom/StudyroomTitle.tsx
@@ -14,24 +14,18 @@ import { useToastStore } from "@/store/useToastStore";
 import BabyLionImg from "../../../assets/image/babyLion.png";
 import BigLionImg from "../../../assets/image/bigLion.png";
 import { useRouter } from "next/navigation";
-import Loading from "@/app/loading";
 
 const StudyroomTitle = () => {
   const router = useRouter();
 
   const user = useUserStore();
   const id = useStudyroomIdStore(state => state.studyroomId);
-  const { studyroom, loading, error } = useStudyroomDetail(id ?? "");
-  const { isFavorite, handleToggleFavorite } = useFavorite(id ?? "");
+  const { studyroom } = useStudyroomDetail(id ?? "");
   const { showToast } = useToastStore();
 
   if (!id || !user) {
     router.replace("/404");
   }
-
-  // 이후 loading, error 처리
-  if (loading) return <Loading />;
-  if (error) router.replace("/404");
 
   const handleShare = async () => {
     if (!id) return;
@@ -76,7 +70,6 @@ const StudyroomTitle = () => {
         </div>
       </div>
     );
-  else router.replace("/404");
 };
 
 export default StudyroomTitle;


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버

<!-- ex) close #1 -->

## ✅ 작업 목록
- 로딩 상태 개선
 기존 studyroomMain의 하위 컴포넌트에서의 loading 컴포넌트 호출로 인해 부자연스러운 로딩 상황이 존재했음.
따라서 전체 컴포넌트인 studyroomMain에서 전역으로 관리되는 studyroomDetail의 loading 상태를 참조해 loading 컴포넌트를 호출하였고, 이를 통해 메인에서는 서브 컴포넌트에서 데이터를 다 받아와 렌더링할 수 있을 때까지 전체 화면 로딩을 유지할 수 있게 되었음.

- pagination시 scroll 상단 이동
```ts
window.scrollTo({ top: 0, behavior: "smooth" });
```
<!-- 이슈 작업한 내용 -->

## 🍰 논의사항

<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC

<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
