### PR TITLE
Refactor: 댓글 작업 리팩토링

### DIFF
--- a/src/app/_component/domain/readArticle/ArticleMain.tsx
+++ b/src/app/_component/domain/readArticle/ArticleMain.tsx
@@ -1,9 +1,13 @@
-import React from "react";
+"use client";
+
+import React, { useState } from "react";
 
 import ArticleList from "@/app/_component/domain/readArticle/ArticleList";
 import ArticleContent from "@/app/_component/domain/readArticle/ArticleContent";
 import Comment from "@/app/_component/domain/readArticle/Comment";
+import Toast from "@/app/_component/common/Toast";
 import styles from "./ArticleMain.module.css";
+import { useToastStore } from "@/store/useToastStore";
 
 interface Props {
   articleId: string;
@@ -11,6 +15,18 @@ interface Props {
 }
 
 export default function ArticleMain({ articleId, studyroomId }: Props) {
+  // 토스트 메시지 타입
+  const { toastType } = useToastStore();
+  // 토스트 표시 여부를 관리하는 로컬 상태
+  const [showToast, setShowToast] = useState(false);
+
+  // toastType이 변경될 때마다 토스트를 표시
+  React.useEffect(() => {
+    if (toastType) {
+      setShowToast(true);
+    }
+  }, [toastType]);
+
   return (
     <>
       <div className={styles.wrapper}>
@@ -20,6 +36,8 @@ export default function ArticleMain({ articleId, studyroomId }: Props) {
           <Comment articleId={articleId} studyroomId={studyroomId} />
         </div>
       </div>
+
+      {showToast && toastType && <Toast toastType={toastType} />}
     </>
   );
 }

--- a/src/app/_component/domain/readArticle/Comment.module.css
+++ b/src/app/_component/domain/readArticle/Comment.module.css
@@ -20,10 +20,10 @@
 .commentsArea {
   display: flex;
   flex-direction: column;
-  max-height: 500px;
+  max-height: 50rem;
   overflow-y: auto;
   scroll-behavior: smooth;
-  padding-right: 10px;
+  padding-right: 1rem;
   gap: 2.2rem;
   padding: 1.6rem;
 
@@ -161,34 +161,30 @@
 
 .fileName {
   display: flex;
-  height: 26px;
-  padding: 2px 8px;
+  height: 2.6rem;
+  padding: 0.5rem 0.8rem;
   justify-content: center;
   align-items: center;
-  gap: 8px;
-  border-radius: 2px;
-  border: 0.5px solid var(--10, #c6c6c6);
-  background: var(--BG_White, #f3f5f7);
-  color: var(--Basic-Black, #000);
+  gap: 0.8rem;
 
-  /* Web/Pretendard/Body8 */
+  border-radius: 2px;
+  border: 0.5px solid #c6c6c6;
+  background: #f3f5f7;
+
+  color: #000;
   font-family: Pretendard;
-  font-size: 10px;
+  font-size: 1rem;
   font-style: normal;
   font-weight: 400;
-  line-height: 16px; /* 160% */
+  line-height: 1.6rem;
+}
 
+.nameInner {
+  max-width: 25.47rem;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
   word-break: break-all;
-}
-
-.fileName span {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: calc(100% - 30px);
 }
 
 .deleteFileBtn {
@@ -235,7 +231,7 @@
 
 .noComment {
   display: flex;
-  padding: 16px 14px;
+  padding: 1.6rem 1.4rem;
   justify-content: center;
   align-items: flex-start;
   margin-bottom: -2rem;
@@ -279,25 +275,34 @@
 }
 
 .fileAttachment {
-  max-width: 23.5rem;
+  max-width: 23rem;
   display: flex;
-  padding: 2px 2px 2px 8px;
+  height: 2.6rem;
+  padding: 0 0.8rem;
   justify-content: center;
   align-items: center;
-  gap: 8px;
-
+  gap: 0.8rem;
   border-radius: 2px;
-  border: 0.5px solid var(--10, #c6c6c6);
-  background: var(--BG_White, #f3f5f7);
+  border: 0.5px solid #c6c6c6;
+  background: #f3f5f7;
+
+  margin-top: 0.5rem;
 }
 
-.fileAttachment span {
+.fileNameInner {
+  width: 100%;
+
   color: #000;
   font-family: Pretendard;
   font-size: 1rem;
   font-style: normal;
   font-weight: 400;
   line-height: 1.6rem;
+
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  word-break: break-all;
 }
 
 .downloadBtn {

--- a/src/app/_component/domain/readArticle/Comment.module.css
+++ b/src/app/_component/domain/readArticle/Comment.module.css
@@ -20,11 +20,22 @@
 .commentsArea {
   display: flex;
   flex-direction: column;
+  max-height: 500px;
+  overflow-y: auto;
+  scroll-behavior: smooth;
+  padding-right: 10px;
   gap: 2.2rem;
   padding: 1.6rem;
 
   border-radius: 10px;
   background-color: #fff;
+
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.commentsArea:-webkit-scrollbar {
+  display: none;
 }
 
 .commentInner {
@@ -300,4 +311,13 @@
 
 .fileAttachmentWrapper {
   display: flex;
+}
+
+.loadingContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 10rem;
+  padding-top: 4rem;
+  width: 100%;
 }

--- a/src/app/_component/domain/readArticle/Comment.module.css
+++ b/src/app/_component/domain/readArticle/Comment.module.css
@@ -326,3 +326,13 @@
   padding-top: 4rem;
   width: 100%;
 }
+
+.link {
+  color: #0077ff;
+  word-break: break-all;
+}
+
+.link:hover {
+  color: #0067dd;
+  text-decoration: underline;
+}

--- a/src/app/_component/domain/readArticle/Comment.tsx
+++ b/src/app/_component/domain/readArticle/Comment.tsx
@@ -51,8 +51,10 @@ const Comment = ({ articleId, studyroomId }: Props) => {
   const [comments, setComments] = useState<CommentData[]>([]);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+
   const { name, year, uid } = useUserStore();
   const showToast = useToastStore(state => state.showToast);
+
   const fileInputRef = useRef<HTMLInputElement>(null);
   const commentsAreaRef = useRef<HTMLDivElement>(null);
   const prevCommentsLengthRef = useRef(0);
@@ -154,7 +156,21 @@ const Comment = ({ articleId, studyroomId }: Props) => {
     }
   };
 
+  const handleFileButtonClick = (e: React.MouseEvent) => {
+    if (selectedFile) {
+      e.preventDefault();
+      e.stopPropagation();
+      showToast("fail_upload");
+      return;
+    }
+  };
+
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (selectedFile) {
+      e.preventDefault();
+      showToast("fail_upload");
+      return;
+    }
     if (e.target.files && e.target.files[0]) {
       setSelectedFile(e.target.files[0]);
     }
@@ -268,7 +284,11 @@ const Comment = ({ articleId, studyroomId }: Props) => {
               style={{ border: "none", width: "100%", paddingRight: "4rem", outline: "none" }}
             />
             <div className={styles.buttonGroup}>
-              <label className={styles.fileButton}>
+              <label
+                className={styles.fileButton}
+                onClick={handleFileButtonClick}
+                onMouseDown={handleFileButtonClick}
+              >
                 <input
                   ref={fileInputRef}
                   type="file"

--- a/src/app/_component/domain/readArticle/Comment.tsx
+++ b/src/app/_component/domain/readArticle/Comment.tsx
@@ -17,6 +17,7 @@ import { formatDate } from "@/utils/formatDate";
 import { useUserStore } from "@/store/useUserStore";
 import { useToastStore } from "@/store/useToastStore";
 import { sortArrByTime } from "@/utils/sortArrByTime";
+import { convertUrlsToLinks } from "@/utils/convertUrlsToLinks";
 import Spinner from "@/app/_component/common/Spinner";
 
 import Image from "next/image";
@@ -231,7 +232,9 @@ const Comment = ({ articleId, studyroomId }: Props) => {
                     </div>
                   </div>
                   <div className={styles.commentInner}>
-                    <div className={styles.commentContent}>{comment.content}</div>
+                    <div className={styles.commentContent}>
+                      {convertUrlsToLinks(comment.content)}
+                    </div>
 
                     {uid && comment.uid === uid && (
                       <button

--- a/src/app/_component/domain/readArticle/Comment.tsx
+++ b/src/app/_component/domain/readArticle/Comment.tsx
@@ -245,7 +245,7 @@ const Comment = ({ articleId, studyroomId }: Props) => {
                   {comment.fileName && (
                     <div className={styles.fileAttachmentWrapper}>
                       <div className={styles.fileAttachment}>
-                        <span>{comment.fileName}</span>
+                        <div className={styles.fileNameInner}>{comment.fileName}</div>
                         <button
                           className={styles.downloadBtn}
                           onClick={() =>
@@ -268,7 +268,7 @@ const Comment = ({ articleId, studyroomId }: Props) => {
         {selectedFile && (
           <div className={styles.fileNameWrapper}>
             <div className={styles.fileName}>
-              {selectedFile.name}
+              <div className={styles.nameInner}>{selectedFile.name}</div>
               <button className={styles.deleteFileBtn} onClick={handleResetFile}>
                 <ICDelete />
               </button>

--- a/src/constants/ToastTypeList.ts
+++ b/src/constants/ToastTypeList.ts
@@ -162,6 +162,12 @@ export const ToastTypeList: ToastItem[] = [
     subtitle: "",
     color: "green"
   },
+  {
+    type: "fail_upload",
+    title: "파일은 1개만 첨부 가능합니다.",
+    subtitle: "",
+    color: "yellow"
+  },
 
   // tag
   {

--- a/src/utils/convertUrlsToLinks.tsx
+++ b/src/utils/convertUrlsToLinks.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from "react";
+import styles from "@/app/_component/domain/readArticle/Comment.module.css";
+
+// http:// 또는 https:// 로 시작하는 문자열을 잘라 a 태그로 바꿔주는 함수
+export const convertUrlsToLinks = (text: string): ReactNode[] => {
+  const urlRegex = /(https?:\/\/[^\s]+)/g;
+  return text.split(urlRegex).map((part, index) => {
+    if (part.match(urlRegex)) {
+      return (
+        <a
+          key={index}
+          href={part}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.link}
+          onClick={e => e.stopPropagation()}
+        >
+          {part}
+        </a>
+      );
+    }
+    return part;
+  });
+};


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
close #99 
구구... ^_^

## ✅ 작업 목록
- [x] css 파일 코드 정리
- [x] 첨부파일 이름 너무 길 경우 줄바꿈
- [x] 댓글 DB 순서가 아닌 최신순 정렬
- [x] 첨부파일 2개 이상 등록 시 토스트
- [x] 댓글 많아질 경우 내부 컨테이너 스크롤 가능하도록 변경
- [x] 댓글 많아진 상태에서 추가할 경우 생성된 위치로 스크롤 내려가도록
- [x] 링크 바로 가기
- [x] 댓글 데이터 페칭 사이에 스피너 추가

## 🍰 논의사항
http:// 또는 https:// 로 시작하는 문자열을 잘라 a 태그로 바꿔주는 함수 `convertUrlsToLinks`를 생성했습니다.
string 타입의 매개변수를 http://, https:// 기준으로 잘라내 a 태그로 반환해주는 함수입니다.

## 📷 ETC
<img width="364" alt="image" src="https://github.com/user-attachments/assets/e5fcd92a-9933-4fb7-879c-2d9f5ce397fe" />

