### PR TITLE
Feat : 스터디룸의 아티클 아이템 tag 렌더링

### DIFF
--- a/src/app/_component/domain/readArticle/ArticleList.tsx
+++ b/src/app/_component/domain/readArticle/ArticleList.tsx
@@ -89,7 +89,7 @@ const ArticleList = ({ articleId, studyroomId }: ArticleListProps) => {
 
   // // 아티클을 클릭한 경우
   const handleClick = (clickedArticleId: string) => {
-    router.push(`/studyroom/${studyroomId}/article/${clickedArticleId}`);
+    router.replace(`/studyroom/${studyroomId}/article/${clickedArticleId}`);
   };
 
   const handleBack = () => {

--- a/src/app/_component/studyroom/Article.module.css
+++ b/src/app/_component/studyroom/Article.module.css
@@ -59,7 +59,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
-  gap: 0.6rem;
+  gap: 1rem;
   padding: 2rem 2rem 2rem 0;
 }
 
@@ -78,6 +78,15 @@
   gap: 0.4rem;
 }
 
+.tagContainer {
+  flex-wrap: wrap;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 0.2rem;
+}
+
 .titleDateWrapper {
   width: 100%;
   display: flex;
@@ -93,6 +102,7 @@
 
   font-size: 1.6rem;
   font-weight: 600;
+  line-height: 2.2rem;
 }
 
 .contentContainer {

--- a/src/app/_component/studyroom/Article.module.css
+++ b/src/app/_component/studyroom/Article.module.css
@@ -59,7 +59,23 @@
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
+  gap: 0.6rem;
   padding: 2rem 2rem 2rem 0;
+}
+
+.topContainer {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
+}
+
+.bottomContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.4rem;
 }
 
 .titleDateWrapper {
@@ -81,7 +97,6 @@
 
 .contentContainer {
   width: 100%;
-  max-height: 6rem;
 
   display: flex;
   flex-direction: column;

--- a/src/app/_component/studyroom/Article.tsx
+++ b/src/app/_component/studyroom/Article.tsx
@@ -45,36 +45,45 @@ const ArticleItem = ({ articleProps, handleRead, isMyArticle }: ArticeItemInterf
         />
       </div>
       <div className={style.mainContentWrapper}>
-        <div className={style.titleDateWrapper}>
-          {/* space-between */}
-          <div className={style.articleTitle}>{articleProps.title}</div>
-          <div className={commonStyles.contentInfo} id={commonStyles.infoContent}>
-            {formatDate(articleProps.createdAt)}
-          </div>
-        </div>
-        {/* 프로필 정보 */}
-        <div className={commonStyles.subContainer} id={style.profileContainer}>
-          <Image
-            className={commonStyles.profileImgContainer}
-            src={articleProps.creatorYear == 13 ? BabyLionImg : BigLionImg}
-            alt="프로필 사진"
-            unoptimized={true}
-            style={{ width: 28, height: 28 }}
-          ></Image>
-          <div className={commonStyles.subTextContainer} id={style.creatorInfoContainer}>
-            <div className={commonStyles.nameContainer} id={style.fontSize12}>
-              {articleProps.creatorName}
+        <div className={style.topContainer}>
+          {/* 날짜 & 프로필 */}
+          <div className={style.titleDateWrapper}>
+            {/* space-between */}
+            <div className={style.articleTitle} id={commonStyles.overflowEllipsisLine1}>
+              {articleProps.title}
             </div>
-            <span id={style.fontSize08}>{articleProps.creatorYear}기</span>
+            <div className={commonStyles.contentInfo} id={commonStyles.infoContent}>
+              {formatDate(articleProps.createdAt)}
+            </div>
+          </div>
+          {/* 프로필 정보 */}
+          <div className={commonStyles.subContainer} id={style.profileContainer}>
+            <Image
+              className={commonStyles.profileImgContainer}
+              src={articleProps.creatorYear == 13 ? BabyLionImg : BigLionImg}
+              alt="프로필 사진"
+              unoptimized={true}
+              style={{ width: 28, height: 28 }}
+            ></Image>
+            <div className={commonStyles.subTextContainer} id={style.creatorInfoContainer}>
+              <div className={commonStyles.nameContainer} id={style.fontSize12}>
+                {articleProps.creatorName}
+              </div>
+              <span id={style.fontSize08}>{articleProps.creatorYear}기</span>
+            </div>
           </div>
         </div>
 
-        {/* 태그 추가 예정 */}
-        <div className={style.contentContainer}>
-          <div className={style.content} id={commonStyles.overflowEllipsisLine3}>
-            {articleProps.content}
+        <div className={style.bottomContainer}>
+          {/* 태그 & content */}
+          <div>{/* 태그 */}</div>
+          <div className={style.contentContainer}>
+            <div className={style.content} id={commonStyles.overflowEllipsisLine3}>
+              {articleProps.content}
+            </div>
           </div>
         </div>
+        {/* 태그 추가 예정 */}
       </div>
     </div>
   );

--- a/src/app/_component/studyroom/CommonStyles.module.css
+++ b/src/app/_component/studyroom/CommonStyles.module.css
@@ -166,7 +166,7 @@
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
 
-  overflow: hidden;
+  overflow-y: hidden;
   text-overflow: ellipsis;
   white-space: normal;
 }
@@ -176,7 +176,7 @@
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 
-  overflow: hidden;
+  overflow-y: hidden;
   text-overflow: ellipsis;
   white-space: normal;
 }
@@ -186,7 +186,7 @@
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
 
-  overflow: hidden;
+  overflow-y: hidden;
   text-overflow: ellipsis;
   white-space: normal;
 }

--- a/src/app/_component/studyroom/StudyroomTitle.module.css
+++ b/src/app/_component/studyroom/StudyroomTitle.module.css
@@ -29,7 +29,7 @@
 }
 
 .title {
-  max-width: 50rem;
+  /* max-width: 50rem; */
   max-height: 2.3rem;
 }
 

--- a/src/app/_component/studyroom/TagItem.module.css
+++ b/src/app/_component/studyroom/TagItem.module.css
@@ -1,0 +1,22 @@
+.tagContainer {
+  display: flex;
+  height: 2rem;
+  padding: 0.6rem 1rem;
+  justify-content: center;
+  align-items: center;
+  gap: 0.275rem;
+
+  border-radius: 0.6874rem;
+  border: 0.687px solid #e6e6e6;
+  background: var(--Basic-White, #fff);
+}
+
+.tagName {
+  color: var(--90, #1a1a1a);
+
+  font-family: Pretendard;
+  font-size: 0.8249rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.3749rem; /* 166.667% */
+}

--- a/src/app/_component/studyroom/TagItem.tsx
+++ b/src/app/_component/studyroom/TagItem.tsx
@@ -1,0 +1,25 @@
+import style from "./TagItem.module.css";
+
+interface TagItemProps {
+  name: string;
+  color: string;
+}
+
+const TagItem = ({ name, color }: TagItemProps) => {
+  return (
+    <div className={style.tagContainer}>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="0.4rem"
+        height="0.4rem"
+        viewBox="0 0 4 4"
+        fill={color}
+      >
+        <circle cx="2" cy="2" r="2" fill={color} />
+      </svg>
+      <div className={style.tagName}>{name}</div>
+    </div>
+  );
+};
+
+export default TagItem;

--- a/src/hooks/useArticles.ts
+++ b/src/hooks/useArticles.ts
@@ -32,7 +32,8 @@ export function useArticles(studyroomId: string) {
           creatorId: data.creatorId,
           createdAt: data.createdAt,
           creatorName: data.creatorName,
-          creatorYear: data.creatorYear
+          creatorYear: data.creatorYear,
+          tags: data.tags
         };
       });
 

--- a/src/hooks/useTagHandler.ts
+++ b/src/hooks/useTagHandler.ts
@@ -1,6 +1,7 @@
 import { collection, doc, getDocs, writeBatch } from "firebase/firestore";
 import fireStore from "@/firebase/firestore";
 import { TagColors } from "@/constants/TagColors";
+import { Tag } from "@/types/studyRoomDetails/article";
 
 const getRandomColor = () => {
   return TagColors[Math.floor(Math.random() * TagColors.length)];
@@ -36,5 +37,18 @@ export const useTagHandler = () => {
     return finalTagIds;
   };
 
-  return { fetchAndPrepareTags };
+  // commonTag를 fetch만 하는 함수
+  const fetchAllCommonTags = async () => {
+    const commonTagRef = collection(fireStore, "commonTags");
+    const snapshot = await getDocs(commonTagRef);
+    return snapshot.docs.map(doc => ({
+      id: doc.id,
+      ...doc.data()
+    })) as Tag[];
+  };
+
+  return {
+    fetchAndPrepareTags,
+    fetchAllCommonTags
+  };
 };

--- a/src/types/studyRoomDetails/article.ts
+++ b/src/types/studyRoomDetails/article.ts
@@ -1,3 +1,9 @@
+export type Tag = {
+  id: string;
+  name: string;
+  color: string;
+};
+
 export type ArticleItemInput = {
   title: string;
   content: string;
@@ -14,4 +20,5 @@ export type ArticleItem = {
   createdAt: any;
   creatorName: string;
   creatorYear: number;
+  tags: string[];
 };


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
#93 
<!-- ex) close #1 -->

## ✅ 작업 목록
아티클의 Tag id 목록을 가져와 commonTags 배열과 map하여 알맞은 색, 이름을 아티클 아이템에 렌더링해주었습니다.

### <주요 작업>
#### 1. commonTags를 불러오는 함수를 useTagHandler에 추가
```tsx
const fetchAllCommonTags = async () => {
    const commonTagRef = collection(fireStore, "commonTags");
    const snapshot = await getDocs(commonTagRef);
    return snapshot.docs.map(doc => ({
      id: doc.id,
      ...doc.data()
    })) as Tag[];
  };
```

#### 2. useArticle에서 article의 tag 배열 속성을 함께 가져옴

#### 3. 각 article의 tag와 commonTags를 매핑하여 알맞은 Tag를 렌더링함.
<!-- 이슈 작업한 내용 -->

## 🍰 논의사항

<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC

<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
