### PR TITLE
refactor : 404 깜빡임 해결, 이미지 경로 preview에서 제거, 스타일 수정 및 수정사항 반영

### DIFF
--- a/src/app/_component/domain/readArticle/ArticleMain.tsx
+++ b/src/app/_component/domain/readArticle/ArticleMain.tsx
@@ -12,6 +12,7 @@ import { useArticlesStore } from "@/store/useArticlesStore";
 import Loading from "@/app/loading";
 import NotFound from "@/app/not-found";
 import { ArticleItem } from "@/types/studyRoomDetails/article";
+import { useRouter } from "next/navigation";
 
 interface Props {
   articleId: string;
@@ -19,6 +20,8 @@ interface Props {
 }
 
 export default function ArticleMain({ articleId, studyroomId }: Props) {
+  const router = useRouter();
+
   // 토스트 메시지 타입
   const { toastType } = useToastStore();
   // 토스트 표시 여부를 관리하는 로컬 상태
@@ -41,12 +44,10 @@ export default function ArticleMain({ articleId, studyroomId }: Props) {
   useEffect(() => {
     if (!isLoading && articles.length > 0) {
       const found = articles.find(article => article.id === articleId);
-      if (!found) return;
+      if (!found) router.replace("/404"); // 바로 404로
       else setSingleArticle(found);
     }
   }, [isLoading, articles, articleId]);
-
-  if (singleArticle === null && articles.length > 0) return <NotFound />;
 
   if (isLoading || articles.length === 0 || !singleArticle) {
     return <Loading />;

--- a/src/app/_component/studyroom/Article.module.css
+++ b/src/app/_component/studyroom/Article.module.css
@@ -48,6 +48,7 @@
 .imgWrapper {
   width: 100%;
   height: 100%;
+  max-height: 18.7rem;
   position: relative;
   object-fit: cover;
 

--- a/src/app/_component/studyroom/modal/AddNoticeContentModal.tsx
+++ b/src/app/_component/studyroom/modal/AddNoticeContentModal.tsx
@@ -16,8 +16,8 @@ interface AddNoticeModalContentProps {
   noticeId?: string;
 }
 
-const TITLE_MAX = 50;
-const CONTENT_MAX = 60;
+const TITLE_MAX = 20;
+const CONTENT_MAX = 30;
 
 export default function AddNoticeModalContent({
   initialContent = "",

--- a/src/store/useArticlesStore.ts
+++ b/src/store/useArticlesStore.ts
@@ -45,7 +45,10 @@ export const useArticlesStore = create<ArticleStore>((set, get) => ({
   },
 
   getMarkdownPreview: (markdown, maxLines = 10) => {
-    const plainText = removeMarkdown(markdown);
+    const withoutImage = markdown.replace(/!\[.*?\]\(.*?\)/g, "");
+    // ![alt](url) 패턴을 찾아 없앰.
+
+    const plainText = removeMarkdown(withoutImage);
     const lines = plainText
       .split("\n")
       .map(line => line.trim())


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [x] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
close #132 
close #133 
<!-- ex) close #1 -->

## ✅ 작업 목록
### 1. style 수정 및 수정사항 반영
### 2. 이미지 경로를 article preview에서 제거
```tsx
const withoutImage = markdown.replace(/!\[.*?\]\(.*?\)/g, "");
    // ![alt](url) 패턴을 찾아 없앰.
```
정규식을 통해 이미지 경로를 찾아 빈 문자열로 대체해주었습니다.

### 3. 아티클 아이템 클릭시 404 페이지가 잠깐 보이며 렌더링되는 현상을 해결
https://github.com/user-attachments/assets/b4ff39ef-76a4-4afb-bc95-d6b9e168745e

이전에 작업할 때에 Loading 처리 이전에 아티클 유효성을 확인하지 않으면 무한로딩 현상이 발생하여
```tsx
if (singleArticle === null && articles.length > 0) return <NotFound />;

  if (isLoading || articles.length === 0 || !singleArticle) {
    return <Loading />;
  }
```
다음과 같이 작성했었는데, 이 때문에 아티클이 존재함에도 singleArticle이 상태에 set되기 전에 잠시 NotFound 페이지가 보이는 이슈가 발생했습니다. 따라서 useEffect 내부에서 바로 404 페이지로 replace해줌으로써 해결했습니다.
```tsx
if (!found) router.replace("/404"); // 바로 404로
```


<!-- 이슈 작업한 내용 -->

## 🍰 논의사항

<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC

<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
