### PR TITLE
refactor: reference api 성능 개선 및 ol,  ul 렌더링 안되는 이슈

### DIFF
--- a/src/app/_component/domain/addarticle/MarkdownEditor.tsx
+++ b/src/app/_component/domain/addarticle/MarkdownEditor.tsx
@@ -81,7 +81,9 @@ const MarkdownEditor = ({ setMarkdown, markdown, setLink }: Props) => {
               <a href={href} target="_blank" rel="noopener noreferrer">
                 {children}
               </a>
-            )
+            ),
+            ul: ({ children }) => <ul style={{ listStyleType: "disc" }}>{children}</ul>,
+            ol: ({ children }) => <ol style={{ listStyleType: "decimal" }}>{children}</ol>
           }
         }}
       />

--- a/src/app/_component/domain/readArticle/ArticleContent.tsx
+++ b/src/app/_component/domain/readArticle/ArticleContent.tsx
@@ -144,7 +144,9 @@ const ArticleContent = ({ article, articleId, studyroomId }: Props) => {
               <a href={href} target="_blank" rel="noopener noreferrer">
                 {children}
               </a>
-            )
+            ),
+            ul: ({ children }) => <ul style={{ listStyleType: "disc" }}>{children}</ul>,
+            ol: ({ children }) => <ol style={{ listStyleType: "decimal" }}>{children}</ol>
           }}
         />
       </div>

--- a/src/app/_component/domain/readArticle/Reference.tsx
+++ b/src/app/_component/domain/readArticle/Reference.tsx
@@ -1,9 +1,6 @@
 import React, { useState, useEffect } from "react";
-import { useMicrolink } from "@/hooks/useMicroLink";
-import Spinner from "@/app/_component/common/Spinner";
 import fireStore from "@/firebase/firestore";
 import { doc, getDoc } from "firebase/firestore";
-
 import styles from "./Reference.module.css";
 
 interface Props {
@@ -12,9 +9,9 @@ interface Props {
 }
 
 export default function Reference({ articleId, studyroomId }: Props) {
-  const [links, setLinks] = useState<string[]>([]);
-  const { linkPreviews, loading, error } = useMicrolink(links);
+  const [links, setLinks] = useState<any[]>([]);
 
+  // 링크 데이터 페치
   useEffect(() => {
     const fetchLinks = async () => {
       try {
@@ -35,39 +32,35 @@ export default function Reference({ articleId, studyroomId }: Props) {
     fetchLinks();
   }, [articleId, studyroomId]);
 
+  // 링크가 있을 경우에만
+  if (links.length === 0) {
+    return null;
+  }
+
   return (
-    <>
-      <div className={styles.wrapper}>
-        <h1>레퍼런스(Link)</h1>
-        <div className={styles.referenceContainer}>
-          {loading && (
-            <div className={styles.loadingContainer}>
-              <Spinner />
-            </div>
-          )}
-          {error && <p>{error}</p>}
+    <div className={styles.wrapper}>
+      <h1>레퍼런스(Link)</h1>
+      <div className={styles.referenceContainer}>
+        {links.map((link, index) => {
+          const imageUrl = link.image?.url || "/default_thumbnail.png";
 
-          {linkPreviews.map((link, index) => {
-            const imageUrl = link.image?.url || "/default_thumbnail.png";
-
-            return (
-              <a
-                key={index}
-                href={link.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={styles.referenceBox}
-              >
-                <img className={styles.profileImgContainer} src={imageUrl} alt="썸네일" />
-                <div className={styles.referenceText}>
-                  <h1>{link.title}</h1>
-                  <h2>{link.url}</h2>
-                </div>
-              </a>
-            );
-          })}
-        </div>
+          return (
+            <a
+              key={index}
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.referenceBox}
+            >
+              <img className={styles.profileImgContainer} src={imageUrl} alt="썸네일" />
+              <div className={styles.referenceText}>
+                <h1>{link.title}</h1>
+                <h2>{link.url}</h2>
+              </div>
+            </a>
+          );
+        })}
       </div>
-    </>
+    </div>
   );
 }

--- a/src/hooks/useArticleSubmit.ts
+++ b/src/hooks/useArticleSubmit.ts
@@ -2,6 +2,7 @@ import { doc, collection, writeBatch, serverTimestamp, arrayUnion } from "fireba
 import fireStore from "@/firebase/firestore";
 import { useToastStore } from "@/store/useToastStore";
 import { useTagHandler } from "./useTagHandler";
+import { MicrolinkData } from "@/types/articles/microlink";
 
 export const useArticleSubmit = ({
   uid,
@@ -33,11 +34,10 @@ export const useArticleSubmit = ({
     articleId?: string;
     title: string;
     markdown: string;
-    link: string;
+    link: MicrolinkData[];
     tags: string[];
     imgUrls: string[];
   }) => {
-    const parsedLink = link ? JSON.parse(link) : [];
     const batch = writeBatch(fireStore);
 
     const finalTagIds = await fetchAndPrepareTags(tags, batch);
@@ -49,7 +49,7 @@ export const useArticleSubmit = ({
         title,
         content: markdown,
         updatedAt: serverTimestamp(),
-        link: parsedLink,
+        link: link,
         tags: finalTagIds,
         imgUrls
       });
@@ -62,7 +62,7 @@ export const useArticleSubmit = ({
         creatorYear: year,
         creatorId: uid,
         createdAt: serverTimestamp(),
-        link: parsedLink,
+        link: link,
         tags: finalTagIds,
         imgUrls
       });

--- a/src/hooks/useFetchMicroLink.ts
+++ b/src/hooks/useFetchMicroLink.ts
@@ -1,0 +1,16 @@
+import { MicrolinkData } from "@/types/articles/microlink";
+
+export const useFetchMicroLink = async (url: string): Promise<MicrolinkData | null> => {
+  try {
+    const res = await fetch(`https://api.microlink.io/?url=${encodeURIComponent(url)}`);
+    const json = await res.json();
+    if (json.status === "success") {
+      const { title, url: realUrl, image } = json.data;
+      return { title, url: realUrl, image };
+    }
+    return null;
+  } catch (err) {
+    console.error(`❌ Error fetching preview for ${url}:`, err);
+    return null;
+  }
+};

--- a/src/types/articles/microlink.ts
+++ b/src/types/articles/microlink.ts
@@ -1,0 +1,7 @@
+export interface MicrolinkData {
+  title: string;
+  url: string;
+  image?: {
+    url: string;
+  };
+}


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [x] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버

<!-- ex) close #1 -->
#131 

## ✅ 작업 목록

<!-- 이슈 작업한 내용 -->
### 1. 레퍼런스 성능 개선
- 기존에 아티클 본문 페이지에서 매번 api 불러오던 방식에서 
   작성하기 버튼 누르면 api에서 페치하는 데이터 중 썸네일 url, title, url만 파싱해 firebase에 저장하고, reference에서 불러오도록 했습니다 (야호)

### 2. 마크다운 프리뷰, 본문 ol, ul 적용 안되는 이슈
- uiw에서 기본적으로는 들여쓰기로만 적용되기 때문에 따로 설정해주었습니다
```
   ul: ({ children }) => <ul style={{ listStyleType: "disc" }}>{children}</ul>,
   ol: ({ children }) => <ol style={{ listStyleType: "decimal" }}>{children}</ol>
```

## 🍰 논의사항

<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->
uiw는 정말 하나하나 다 지정해줘야 하네요..😅

## 📷 ETC

<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
