### PR TITLE
Fix: 댓글 섹션 스크롤 기본 위치를 맨 아래로 설정 및 댓글 중복 입력 방지

### DIFF
--- a/src/app/_component/domain/readArticle/Comment.tsx
+++ b/src/app/_component/domain/readArticle/Comment.tsx
@@ -80,24 +80,21 @@ const Comment = ({ articleId, studyroomId }: Props) => {
       setComments(sortedComments);
       setIsLoading(false);
 
-      // 마지막 댓글 ID가 있고, 새로운 댓글이 추가된 경우에만 스크롤
-      if (lastCommentId && sortedComments.length > 0) {
-        const lastComment = sortedComments[sortedComments.length - 1];
-        if (lastComment.commentId === lastCommentId) {
-          setTimeout(() => {
-            if (commentsAreaRef.current) {
-              commentsAreaRef.current.scrollTo({
-                top: commentsAreaRef.current.scrollHeight,
-                behavior: "smooth"
-              });
-            }
-          }, 100);
-        }
+      // 초기 로딩이 완료되거나 새로운 댓글이 추가된 경우 스크롤
+      if (!isLoading || (lastCommentId && sortedComments.length > 0)) {
+        setTimeout(() => {
+          if (commentsAreaRef.current) {
+            commentsAreaRef.current.scrollTo({
+              top: commentsAreaRef.current.scrollHeight,
+              behavior: "smooth"
+            });
+          }
+        }, 100);
       }
     });
 
     return () => unsub();
-  }, [articleId, studyroomId, lastCommentId]);
+  }, [articleId, studyroomId, lastCommentId, isLoading]);
 
   const handleSubmit = async () => {
     if (!commentText.trim() && !selectedFile) {

--- a/src/app/_component/domain/readArticle/Comment.tsx
+++ b/src/app/_component/domain/readArticle/Comment.tsx
@@ -53,6 +53,7 @@ const Comment = ({ articleId, studyroomId }: Props) => {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [lastCommentId, setLastCommentId] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { name, year, uid } = useUserStore();
   const showToast = useToastStore(state => state.showToast);
@@ -101,7 +102,12 @@ const Comment = ({ articleId, studyroomId }: Props) => {
       return;
     }
 
+    if (isSubmitting) {
+      return;
+    }
+
     try {
+      setIsSubmitting(true);
       let imageUrl = null;
 
       if (selectedFile) {
@@ -112,6 +118,7 @@ const Comment = ({ articleId, studyroomId }: Props) => {
         } catch (uploadError) {
           console.error("파일 업로드 중 오류 발생:", uploadError);
           showToast("fail");
+          setIsSubmitting(false);
           return;
         }
       }
@@ -138,6 +145,8 @@ const Comment = ({ articleId, studyroomId }: Props) => {
     } catch (error) {
       console.error("댓글 작성 중 오류 발생:", error);
       showToast("fail");
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -285,6 +294,7 @@ const Comment = ({ articleId, studyroomId }: Props) => {
               value={commentText}
               onChange={e => setCommentText(e.target.value)}
               style={{ border: "none", width: "100%", paddingRight: "4rem", outline: "none" }}
+              disabled={isSubmitting}
             />
             <div className={styles.buttonGroup}>
               <label
@@ -297,6 +307,7 @@ const Comment = ({ articleId, studyroomId }: Props) => {
                   type="file"
                   onChange={handleFileChange}
                   style={{ display: "none" }}
+                  disabled={isSubmitting}
                 />
                 <ICFile />
               </label>
@@ -305,7 +316,7 @@ const Comment = ({ articleId, studyroomId }: Props) => {
           <button
             className={`${styles.submitBtn} ${isSubmitEnabled ? styles.active : ""}`}
             onClick={handleSubmit}
-            disabled={!isSubmitEnabled}
+            disabled={!isSubmitEnabled || isSubmitting}
             type="button"
           >
             <ICUpload />


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
close #135 

## ✅ 작업 목록
## 댓글 섹션 스크롤 기본위치 맨 아래로
### 변경사항
- 댓글 섹션의 스크롤 위치를 기본적으로 맨 아래로 설정하도록 수정했습니다.
- 초기 로딩 완료 시와 새로운 댓글 추가 시 스크롤이 자동으로 맨 아래로 이동하도록 구현했습니다.

### 변경 이유
- 기존에는 새로운 댓글이 추가될 때만 스크롤이 맨 아래로 이동하여, 페이지 진입 시 최신 댓글을 보기 위해 수동으로 스크롤해야 하는 불편함이 있었습니다.
- 사용자 경험 개선을 위해 댓글 섹션 접근 시 항상 최신 댓글을 볼 수 있도록 수정했습니다.

### 구현 방법
- `useEffect` 내에서 스크롤 로직을 수정하여 다음 두 가지 경우에 스크롤이 맨 아래로 이동하도록 구현:
  1. 초기 로딩이 완료될 때 (`!isLoading`)
  2. 새로운 댓글이 추가될 때 (`lastCommentId && sortedComments.length > 0`)
- `useEffect` 의존성 배열에 `isLoading` 추가하여 로딩 상태 변경을 감지할 수 있도록 수정

## 댓글 중복 입력 방지
### 변경사항
- 댓글 중복 제출 방지 기능을 추가했습니다.
- 댓글 제출 중에는 입력 필드와 버튼이 비활성화되도록 구현했습니다.

###  변경 이유
- 기존에는 댓글 제출 버튼을 빠르게 여러 번 클릭하면 동일한 댓글이 여러 번 등록되는 문제가 있었습니다.
- 사용자 실수로 인한 중복 댓글 등록을 방지하기 위함입니다.

###  구현 방법
1. 상태 관리 추가
   - `isSubmitting` 상태를 추가하여 댓글 제출 중인지 여부를 추적
   - 제출 시작 시 `true`, 완료/실패 시 `false`로 설정

2. 제출 로직 수정
   - `handleSubmit` 함수에 중복 제출 방지 로직 추가
   - 제출 중일 때는 추가 제출 시도 무시
   - `try-catch-finally` 구문을 사용하여 성공/실패와 관계없이 상태 초기화

3. UI 요소 비활성화
   - 댓글 입력 필드 (`input`) 제출 중 비활성화
   - 파일 업로드 버튼 제출 중 비활성화
   - 제출 버튼 제출 중 또는 입력 없을 때 비활성화

## 📷 ETC


https://github.com/user-attachments/assets/5a187bbf-2a40-48cf-b015-4b358123bbe3

