### PR TITLE
🤖chore: 의존성 배열 수정

### DIFF
--- a/src/app/_component/domain/readArticle/ArticleMain.tsx
+++ b/src/app/_component/domain/readArticle/ArticleMain.tsx
@@ -47,7 +47,7 @@ export default function ArticleMain({ articleId, studyroomId }: Props) {
       if (!found) router.replace("/404"); // 바로 404로
       else setSingleArticle(found);
     }
-  }, [isLoading, articles, articleId]);
+  }, [isLoading, articleId]);
 
   if (isLoading || articles.length === 0 || !singleArticle) {
     return <Loading />;

--- a/src/app/_component/studyroom/modal/DeleteContentModal.tsx
+++ b/src/app/_component/studyroom/modal/DeleteContentModal.tsx
@@ -47,7 +47,7 @@ export default function DeleteContentModal({
 
     // Article일 때만 이동
     if (type === "Article" && studyroomId) {
-      router.push(`/studyroom/${studyroomId}`);
+      router.replace(`/studyroom/${studyroomId}`);
     }
   };
 


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [x] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 🔔 관련된 이슈 넘버
close #140 
<!-- ex) close #1 -->

## ✅ 작업 목록
articleId 유효성 검사 useEffect의 의존성 배열에서 onSnapshot으로 구독되는 articles를 제거

### 기존 흐름
1. article 삭제시 articles 데이터에 변화가 생김 (onSnapshot으로 인한 실시간 변화 감지)
2. 전역으로 관리되는 articles 데이터의 변화로 인해 useEffect 훅 실행
3. articleId의 유효성을 검사시 삭제된 아티클이기에 유효하지 않다고 판단
4. studyroom 이동 이전에 이미 404 페이지로 이동

### 수정된 흐름
useEffect의 의존성 배열에서 articles를 제거함.
articles의 실시간 변화에 따라 지속적으로 article의 유효성을 확인하진 않게 됨.
- 자기 아티클 경로에 있던 중 자신의 아티클 삭제 => 삭제 후 studyroom으로 이동
- 특정 아티클 경로에 있던 중 타인이 해당 아티클 삭제 => 새로고침이나 다른 아티클로 이동하는 등의 리렌더링 발생시 아티클 삭제가 인식됨

### 추가 수정 사항
삭제된 아티클 링크로의 뒤로가기를 방지하기 위해 `router.push`를 `router.replace`로 변경하였습니다.
<!-- 이슈 작업한 내용 -->

## 🍰 논의사항

<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC

<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
