### PR TITLE
Chore: 구글 애널리틱스 태그 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "@toast-ui/editor/dist/toastui-editor.css";
 import "./styles/globals.css";
 import "./styles/reset.css";
 import Modal from "./_component/common/Modal";
+import Script from "next/script";
 
 export const metadata: Metadata = {
   title: "사자의 서재",
@@ -49,6 +50,18 @@ export default function RootLayout({
         <meta property="og:image:height" content="400" />
         <meta property="og:url" content="https://lion-s-study.vercel.app/" />
         <meta property="og:type" content="website" />
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-WVQRZ7YXGX"
+          strategy="afterInteractive"
+        />
+        <Script id="gtag-init" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){ dataLayer.push(arguments); }
+            gtag('js', new Date());
+            gtag('config', 'G-WVQRZ7YXGX');
+          `}
+        </Script>
       </head>
       <body>
         <div id="modal-root" />


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [x] ETC

## 🔔 관련된 이슈 넘버

<!-- ex) close #1 -->

## ✅ 작업 목록
구글 애널리틱스 설정을 위한 태그 추가
<img width="655" alt="스크린샷 2025-06-23 오후 10 39 50" src="https://github.com/user-attachments/assets/6b5234c6-425a-4464-9b7e-e4a3547d3dc0" />
다음과 같은 태그를 RootLayout에 추가하기 위해 기존 head 태그 대신 next/script에서 제공하는 Script 태그를 사용하여 외부 스크립트를 안전하게, 클라이언트 전용으로, 로딩 시점을 명시적으로 삽입하였습니다.
<!-- 이슈 작업한 내용 -->

## 🍰 논의사항

<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC

<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
